### PR TITLE
Pymbar fix

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,4 +1,4 @@
-name: paprika-dev
+name: paprika-devs
 channels:
   - conda-forge
   - ambermd

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,4 +1,4 @@
-name: paprika-devs
+name: paprika-dev
 channels:
   - conda-forge
   - ambermd

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - parmed
   - mdtraj
-  - pymbar > 3.0.3
+  - pymbar >= 3.0.5
   - openmm
   - ambertools=19
   - pyyaml

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -688,7 +688,8 @@ class fe_calc(object):
 
             mbar = pymbar.MBAR(u_kln, frac_N_k, verbose=verbose)
             mbar_results = mbar.getFreeEnergyDifferences(
-                compute_uncertainty=True
+                compute_uncertainty=True,
+                return_dict=True
             )
 
             Deltaf_ij = mbar_results["Delta_f"]
@@ -717,7 +718,8 @@ class fe_calc(object):
                 # correlation in the data.
                 mbar = pymbar.MBAR(u_kln_err, frac_N_ss, verbose=verbose)
                 mbar_results = mbar.getFreeEnergyDifferences(
-                    compute_uncertainty=True
+                    compute_uncertainty=True,
+                    return_dict=True
                 )
                 dDeltaf_ij = mbar_results["dDelta_f"]
                 dDeltaf_ij_N_eff = mbar.computeEffectiveSampleNumber()

--- a/paprika/restraints/restraints.py
+++ b/paprika/restraints/restraints.py
@@ -759,7 +759,7 @@ def static_DAT_restraint(
     num_window_list: list
         A list of windows during which this restraint will be applied, which should be in the form: [attach windows,
         pull windows, release windows].
-    ref_structure: Path-like
+    ref_structure: Path-like or parmed Amber object
         The reference structure that is used to determine the initial, **static** value for this restraint.
     force_constant: float
         The force constant for this restraint.
@@ -793,7 +793,7 @@ def static_DAT_restraint(
         reference_trajectory = pt.iterload(ref_structure, traj=True)
         rest.topology = pmd.load_file(ref_structure, structure=True)
     else:
-        raise Exception(
+        raise TypeError(
             "static_DAT_restraint does not support the type associated with ref_structure:"
             + type(ref_structure)
         )

--- a/paprika/restraints/restraints.py
+++ b/paprika/restraints/restraints.py
@@ -762,7 +762,7 @@ def static_DAT_restraint(
     ref_structure: Path-like
         The reference structure that is used to determine the initial, **static** value for this restraint.
     force_constant: float
-        The force constant for this reestraint.
+        The force constant for this restraint.
     continuous_apr: bool
         Whether this restraint uses ``continuous_apr``. This must be consistent with existing restraints.
     amber_index: bool
@@ -775,8 +775,6 @@ def static_DAT_restraint(
 
     """
 
-    reference_trajectory = pt.iterload(ref_structure, traj=True)
-
     # Check num_window_list
     if len(num_window_list) != 3:
         raise ValueError(
@@ -787,7 +785,19 @@ def static_DAT_restraint(
     rest = DAT_restraint()
     rest.continuous_apr = continuous_apr
     rest.amber_index = amber_index
-    rest.topology = pmd.load_file(ref_structure, structure=True)
+
+    if isinstance(ref_structure, pmd.amber._amberparm.AmberParm):
+        reference_trajectory = pt.load_parmed(ref_structure, traj=True)
+        rest.topology = ref_structure
+    elif isinstance(ref_structure, str):
+        reference_trajectory = pt.iterload(ref_structure, traj=True)
+        rest.topology = pmd.load_file(ref_structure, structure=True)
+    else:
+        raise Exception(
+            "static_DAT_restraint does not support the type associated with ref_structure:"
+            + type(ref_structure)
+        )
+
     rest.mask1 = restraint_mask_list[0]
     rest.mask2 = restraint_mask_list[1]
     if len(restraint_mask_list) >= 3:


### PR DESCRIPTION
* Fixed API for pymbar 3.0.5
* Fixed load structure issue in the function static_DAT_restraint so that it is compatible for both OpenMM and Amber

- [x] This is ready for review.