### PR TITLE
Fix missing import of parmed in tleap.py

### DIFF
--- a/paprika/tleap.py
+++ b/paprika/tleap.py
@@ -3,6 +3,7 @@ import re as re
 import subprocess as sp
 import logging as log
 import numpy as np
+import parmed as pmd
 
 
 N_A = 6.0221409 * 10 ** 23


### PR DESCRIPTION
Forgot to include `import parmed as pmd` in `tleap.py` for the HMR support