### PR TITLE
Remove redundant conda channel

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -2,7 +2,6 @@ name: paprika-dev
 channels:
   - conda-forge
   - omnia
-  - mwt
 dependencies:
   
   # Base depends


### PR DESCRIPTION
`InterMol` is now live on the `conda-forge` channel, so I'm removing the `mwt` channel from the `test_env.yaml` file.