### PR TITLE
Refactor Evaluator related module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         os: [macOS-latest, ubuntu-latest]
         python-version: [3.7]
     env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PYVER: ${{ matrix.python-version }}
       PACKAGE: paprika
 

--- a/docs/source/evaluator.rst
+++ b/docs/source/evaluator.rst
@@ -4,7 +4,7 @@ Evaluator API
 Analysis
 --------
 
-.. automodule:: paprika.analyze
+.. automodule:: paprika.evaluator.analyze
    :members:
    :undoc-members:
    :noindex:
@@ -13,7 +13,21 @@ Analysis
 
 Setup
 -----
-.. automodule:: paprika.setup
+.. automodule:: paprika.evaluator.setup
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+GAFF
+----
+.. automodule:: paprika.evaluator.amber
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Utils
+-----
+.. automodule:: paprika.evaluator.utils
    :members:
    :undoc-members:
    :show-inheritance:

--- a/paprika/__init__.py
+++ b/paprika/__init__.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 import logging
 
-from paprika.analyze import Analyze
+from paprika.evaluator import Analyze
 
 # Handle versioneer
 from ._version import get_versions
@@ -23,7 +23,7 @@ del get_versions, versions
 logger = logging.getLogger(__name__)
 
 try:
-    from paprika.setup import Setup
+    from paprika.evaluator import Setup
 
     setup = Setup
 except ImportError:

--- a/paprika/evaluator/__init__.py
+++ b/paprika/evaluator/__init__.py
@@ -1,0 +1,7 @@
+from .analyze import Analyze
+from .setup import Setup
+
+__all__ = [
+    Analyze,
+    Setup,
+]

--- a/paprika/evaluator/amber.py
+++ b/paprika/evaluator/amber.py
@@ -1,0 +1,213 @@
+"""
+Functions for generate GAFF files and parameters.
+"""
+
+import logging
+import os
+import subprocess
+from typing import Optional
+
+import numpy as np
+import parmed as pmd
+
+logger = logging.getLogger(__name__)
+_PI_ = np.pi
+
+
+def generate_gaff(
+    mol2_file: str,
+    residue_name: str,
+    output_name: Optional[str] = None,
+    need_gaff_atom_types: Optional[bool] = True,
+    generate_frcmod: Optional[bool] = True,
+    directory_path: Optional[str] = "benchmarks",
+    gaff_version: Optional[str] = "gaff2",
+):
+    """
+    Module to generate GAFF files given a mol2 file.
+
+    Parameters
+    ----------
+    mol2_file
+        The name of the mol2 structure file.
+    residue_name
+        The residue name of the molecule.
+    output_name
+        The name for the output file.
+    need_gaff_atom_types
+        Whether to generate GAFF atoms or not. Currently, this is the only choice.
+    gaff_version
+        The GAFF version to use ("gaff1", "gaff2")
+    generate_frcmod
+        Option to generate a GAFF frcmod file.
+    directory_path
+        The working directory where the files will be stored.
+    """
+
+    if output_name is None:
+        output_name = mol2_file.stem
+
+    if need_gaff_atom_types:
+        _generate_gaff_atom_types(
+            mol2_file=mol2_file,
+            residue_name=residue_name,
+            output_name=output_name,
+            gaff_version=gaff_version,
+            directory_path=directory_path,
+        )
+        logging.debug(
+            "Checking to see if we have a multi-residue MOL2 file that should be converted "
+            "to single-residue..."
+        )
+        structure = pmd.load_file(
+            os.path.join(directory_path, f"{output_name}.{gaff_version}.mol2"),
+            structure=True,
+        )
+        if len(structure.residues) > 1:
+            structure[":1"].save("tmp.mol2")
+            if os.path.exists("tmp.mol2"):
+                os.rename(
+                    "tmp.mol2",
+                    os.path.join(directory_path, f"{output_name}.{gaff_version}.mol2"),
+                )
+                logging.debug("Saved single-residue MOL2 file for `tleap`.")
+            else:
+                raise RuntimeError(
+                    "Unable to convert multi-residue MOL2 file to single-residue for `tleap`."
+                )
+
+        if generate_frcmod:
+            _generate_frcmod(
+                mol2_file=f"{output_name}.{gaff_version}.mol2",
+                gaff_version=gaff_version,
+                output_name=output_name,
+                directory_path=directory_path,
+            )
+        else:
+            raise NotImplementedError()
+
+    else:
+        raise NotImplementedError()
+
+
+def _generate_gaff_atom_types(
+    mol2_file: str,
+    residue_name: str,
+    output_name: str,
+    gaff_version: Optional[str] = "gaff2",
+    directory_path: Optional[str] = "benchmarks",
+):
+    """Generate a mol2 file with GAFF atom types."""
+
+    if gaff_version.lower() not in ["gaff", "gaff2"]:
+        raise KeyError(
+            f"Parameter set {gaff_version} not supported. Only [gaff, gaff2] are allowed."
+        )
+
+    p = subprocess.Popen(
+        [
+            "antechamber",
+            "-i",
+            mol2_file,
+            "-fi",
+            "mol2",
+            "-o",
+            f"{output_name}.{gaff_version}.mol2",
+            "-fo",
+            "mol2",
+            "-rn",
+            f"{residue_name.upper()}",
+            "-at",
+            f"{gaff_version}",
+            "-an",
+            "no",
+            "-dr",
+            "no",
+            "-pf",
+            "yes",
+        ],
+        cwd=directory_path,
+    )
+    p.communicate()
+    print(p)
+
+    remove_files = [
+        "ANTECHAMBER_AC.AC",
+        "ANTECHAMBER_AC.AC0",
+        "ANTECHAMBER_BOND_TYPE.AC",
+        "ANTECHAMBER_BOND_TYPE.AC0",
+        "ATOMTYPE.INF",
+    ]
+    files = [os.path.join(directory_path, file) for file in remove_files]
+    for file in files:
+        if os.path.isfile(file):
+            logger.debug(f"Removing temporary file: {file}")
+            file.unlink()
+
+    if not os.path.exists(f"{output_name}.{gaff_version}.mol2"):
+        # Try with the newer (AmberTools 19) version of `antechamber` which doesn't have the `-dr` flag
+        p = subprocess.Popen(
+            [
+                "antechamber",
+                "-i",
+                mol2_file,
+                "-fi",
+                "mol2",
+                "-o",
+                f"{output_name}.{gaff_version}.mol2",
+                "-fo",
+                "mol2",
+                "-rn",
+                f"{residue_name.upper()}",
+                "-at",
+                f"{gaff_version}",
+                "-an",
+                "no",
+                "-pf",
+                "yes",
+            ],
+            cwd=directory_path,
+        )
+        p.communicate()
+
+        remove_files = [
+            "ANTECHAMBER_AC.AC",
+            "ANTECHAMBER_AC.AC0",
+            "ANTECHAMBER_BOND_TYPE.AC",
+            "ANTECHAMBER_BOND_TYPE.AC0",
+            "ATOMTYPE.INF",
+        ]
+        files = [os.path.join(directory_path, file) for file in remove_files]
+        for file in files:
+            if os.path.isfile(file):
+                logger.debug(f"Removing temporary file: {file}")
+                file.unlink()
+
+
+def _generate_frcmod(
+    mol2_file: str,
+    gaff_version: str,
+    output_name: str,
+    directory_path: Optional[str] = "benchmarks",
+):
+    """Generate an AMBER .frcmod file given a mol2 file."""
+
+    if gaff_version.lower() not in ["gaff", "gaff2"]:
+        raise KeyError(
+            f"Parameter set {gaff_version} not supported. Only [gaff, gaff2] are allowed."
+        )
+
+    subprocess.Popen(
+        [
+            "parmchk2",
+            "-i",
+            str(mol2_file),
+            "-f",
+            "mol2",
+            "-o",
+            f"{output_name}.{gaff_version}.frcmod",
+            "-s",
+            f"{gaff_version}",
+        ],
+        cwd=directory_path,
+    )

--- a/paprika/evaluator/analyze.py
+++ b/paprika/evaluator/analyze.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Analyze:
     """
-    The Analyze class provides a wrapper function around the analysis of simulations.
+    The ``Analyze`` class provides a wrapper function around the analysis of simulations.
     """
 
     @classmethod

--- a/paprika/evaluator/setup.py
+++ b/paprika/evaluator/setup.py
@@ -3,13 +3,10 @@ This class contains a simulation setup wrapper for use with the OpenFF Evaluator
 """
 
 import logging
-import os
-import subprocess
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import parmed as pmd
-import pkg_resources
 
 from paprika import align
 from paprika.restraints import DAT_restraint, static_DAT_restraint
@@ -20,7 +17,7 @@ _PI_ = np.pi
 
 class Setup:
     """
-    The Setup class provides a wrapper function around the preparation of the host-guest
+    The ``Setup`` class provides a wrapper function around the preparation of the host-guest
     system and the application of restraints.
     """
 
@@ -607,167 +604,3 @@ class Setup:
             restraints.append(guest_restraint)
 
         return restraints
-
-
-def get_benchmarks():
-    """
-    Determine the installed `taproom` benchmarks.
-    """
-    installed_benchmarks = {}
-
-    for entry_point in pkg_resources.iter_entry_points(group="taproom.benchmarks"):
-        installed_benchmarks[entry_point.name] = entry_point.load()
-
-    return installed_benchmarks
-
-
-def generate_gaff(
-    mol2_file,
-    residue_name,
-    output_name=None,
-    need_gaff_atom_types=True,
-    generate_frcmod=True,
-    directory_path="benchmarks",
-    gaff="gaff2",
-):
-
-    if output_name is None:
-        output_name = mol2_file.stem
-
-    if need_gaff_atom_types:
-        _generate_gaff_atom_types(
-            mol2_file=mol2_file,
-            residue_name=residue_name,
-            output_name=output_name,
-            gaff=gaff,
-            directory_path=directory_path,
-        )
-        logging.debug(
-            "Checking to see if we have a multi-residue MOL2 file that should be converted "
-            "to single-residue..."
-        )
-        structure = pmd.load_file(
-            os.path.join(directory_path, f"{output_name}.{gaff}.mol2"), structure=True
-        )
-        if len(structure.residues) > 1:
-            structure[":1"].save("tmp.mol2")
-            if os.path.exists("tmp.mol2"):
-                os.rename(
-                    "tmp.mol2",
-                    os.path.join(directory_path, f"{output_name}.{gaff}.mol2"),
-                )
-                logging.debug("Saved single-residue MOL2 file for `tleap`.")
-            else:
-                raise RuntimeError(
-                    "Unable to convert multi-residue MOL2 file to single-residue for `tleap`."
-                )
-
-        if generate_frcmod:
-            _generate_frcmod(
-                mol2_file=f"{output_name}.{gaff}.mol2",
-                gaff=gaff,
-                output_name=output_name,
-                directory_path=directory_path,
-            )
-        else:
-            raise NotImplementedError()
-
-
-def _generate_gaff_atom_types(
-    mol2_file, residue_name, output_name, gaff="gaff2", directory_path="benchmarks"
-):
-
-    p = subprocess.Popen(
-        [
-            "antechamber",
-            "-i",
-            str(mol2_file),
-            "-fi",
-            "mol2",
-            "-o",
-            f"{output_name}.{gaff}.mol2",
-            "-fo",
-            "mol2",
-            "-rn",
-            f"{residue_name.upper()}",
-            "-at",
-            f"{gaff}",
-            "-an",
-            "no",
-            "-dr",
-            "no",
-            "-pf",
-            "yes",
-        ],
-        cwd=directory_path,
-    )
-    p.communicate()
-
-    files = [
-        "ANTECHAMBER_AC.AC",
-        "ANTECHAMBER_AC.AC0",
-        "ANTECHAMBER_BOND_TYPE.AC",
-        "ANTECHAMBER_BOND_TYPE.AC0",
-        "ATOMTYPE.INF",
-    ]
-    files = [directory_path.joinpath(i) for i in files]
-    for file in files:
-        if file.exists():
-            logger.debug(f"Removing temporary file: {file}")
-            file.unlink()
-
-    if not os.path.exists(f"{output_name}.{gaff}.mol2"):
-        # Try with the newer (AmberTools 19) version of `antechamber` which doesn't have the `-dr` flag
-        p = subprocess.Popen(
-            [
-                "antechamber",
-                "-i",
-                str(mol2_file),
-                "-fi",
-                "mol2",
-                "-o",
-                f"{output_name}.{gaff}.mol2",
-                "-fo",
-                "mol2",
-                "-rn",
-                f"{residue_name.upper()}",
-                "-at",
-                f"{gaff}",
-                "-an",
-                "no",
-                "-pf",
-                "yes",
-            ],
-            cwd=directory_path,
-        )
-        p.communicate()
-
-        files = [
-            "ANTECHAMBER_AC.AC",
-            "ANTECHAMBER_AC.AC0",
-            "ANTECHAMBER_BOND_TYPE.AC",
-            "ANTECHAMBER_BOND_TYPE.AC0",
-            "ATOMTYPE.INF",
-        ]
-        files = [directory_path.joinpath(i) for i in files]
-        for file in files:
-            if file.exists():
-                logger.debug(f"Removing temporary file: {file}")
-                file.unlink()
-
-
-def _generate_frcmod(mol2_file, gaff, output_name, directory_path="benchmarks"):
-    subprocess.Popen(
-        [
-            "parmchk2",
-            "-i",
-            str(mol2_file),
-            "-f",
-            "mol2",
-            "-o",
-            f"{output_name}.{gaff}.frcmod",
-            "-s",
-            f"{gaff}",
-        ],
-        cwd=directory_path,
-    )

--- a/paprika/evaluator/utils.py
+++ b/paprika/evaluator/utils.py
@@ -1,0 +1,13 @@
+import pkg_resources
+
+
+def get_benchmarks():
+    """
+    Determine the installed ``taproom`` benchmarks.
+    """
+    installed_benchmarks = {}
+
+    for entry_point in pkg_resources.iter_entry_points(group="taproom.benchmarks"):
+        installed_benchmarks[entry_point.name] = entry_point.load()
+
+    return installed_benchmarks

--- a/paprika/tests/test_evaluator.py
+++ b/paprika/tests/test_evaluator.py
@@ -1,0 +1,254 @@
+"""
+Tests evaluator modules.
+"""
+import logging
+import os
+import shutil
+
+import numpy as np
+import parmed as pmd
+import pytest
+import pytraj as pt
+
+from paprika.evaluator import Analyze, Setup
+from paprika.evaluator.amber import generate_gaff
+from paprika.restraints import DAT_restraint
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def clean_files(directory=os.path.join(os.path.dirname(__file__), "tmp")):
+    # This happens before the test function call
+    if os.path.isdir(directory):
+        shutil.rmtree(directory)
+    os.makedirs(directory, exist_ok=True)
+    yield
+    # This happens after the test function call
+    shutil.rmtree(directory)
+
+
+def test_evaluator_setup_structure(clean_files):
+    temporary_directory = os.path.join(os.path.dirname(__file__), "tmp")
+
+    G1 = ":BUT@C"
+    G2 = ":BUT@C3"
+
+    # Test prepare_complex_structure
+    host_guest_pdb = os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb")
+    guest_atom_indices = []
+    structure = pmd.load_file(host_guest_pdb, structure=True)
+    for atom in structure.topology.atoms():
+        if atom.residue.name == "BUT":
+            guest_atom_indices.append(atom.index)
+
+    host_guest_structure_initial = Setup.prepare_complex_structure(
+        host_guest_pdb,
+        guest_atom_indices,
+        f"{G1} {G2}",
+        24.0,
+        0,
+        46,
+    )
+
+    assert all(host_guest_structure_initial[G1].coordinates[0] == [0.0, 0.0, 0.0])
+
+    host_guest_structure_final = Setup.prepare_complex_structure(
+        host_guest_pdb,
+        guest_atom_indices,
+        f"{G1} {G2}",
+        24.0,
+        45,
+        46,
+    )
+    assert all(host_guest_structure_final[G1].coordinates[0] == [0.0, 0.0, 24.0])
+
+    cG1 = host_guest_structure_final[G1].coordinates[0]
+    cG2 = host_guest_structure_final[G2].coordinates[0]
+    vec = cG2 - cG1
+    axis = np.array([0, 0, 1])
+    theta = np.arccos(np.dot(vec, axis) / (np.linalg.norm(vec) * np.linalg.norm(axis)))
+    assert theta == 0.0
+
+    # Test prepare_host_structure
+    structure = pmd.load_file(host_guest_pdb, structure=True)
+    structure[":CB6"].save(os.path.join(temporary_directory, "cb6.pdb"))
+    host_pdb = os.path.join(temporary_directory, "cb6.pdb")
+    host_atom_indices = []
+    for atom in structure.topology.atoms():
+        if atom.residue.name == "CB6":
+            host_atom_indices.append(atom.index)
+
+    host_structure = Setup.prepare_host_structure(
+        host_pdb,
+        host_atom_indices,
+    )
+    center_of_mass = pmd.geometry.center_of_mass(
+        host_structure.coordinates, masses=np.ones(len(host_structure.coordinates))
+    )
+    assert pytest.approx(center_of_mass[0], abs=1e-3) == 0.0
+    assert pytest.approx(center_of_mass[1], abs=1e-3) == 0.0
+    assert pytest.approx(center_of_mass[2], abs=1e-3) == 0.0
+
+    inertia_tensor = np.dot(
+        host_structure.coordinates.transpose(), host_structure.coordinates
+    )
+    eig_val, eig_vec = np.linalg.eig(inertia_tensor)
+    assert pytest.approx(eig_vec[0, -1], abs=1e-3) == 0.0
+    assert pytest.approx(eig_vec[1, -1], abs=1e-3) == 0.0
+    assert pytest.approx(eig_vec[2, -1], abs=1e-3) == 1.0
+
+    # Test add dummy
+    Setup.add_dummy_atoms_to_structure(
+        host_structure,
+        [
+            np.array([0, 0, 0]),
+            np.array([0, 0, -3.0]),
+            np.array([0, 2.2, -5.2]),
+        ],
+        np.zeros(3),
+    )
+    dummy_atoms = []
+    for atom in host_structure.topology.atoms():
+        if atom.name == "DUM":
+            dummy_atoms.append(atom)
+
+    assert len(dummy_atoms) == 3
+    assert pytest.approx(host_structure[":DM1"].coordinates[0][2], abs=1e-3) == 0.0
+    assert pytest.approx(host_structure[":DM2"].coordinates[0][2], abs=1e-3) == -3.0
+    assert pytest.approx(host_structure[":DM3"].coordinates[0][1], abs=1e-3) == 2.2
+    assert pytest.approx(host_structure[":DM3"].coordinates[0][2], abs=1e-3) == -5.2
+
+
+def test_evaluator_analyze(clean_files):
+    input_pdb = os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb")
+    structure = pmd.load_file(input_pdb, structure=True)
+
+    guest_atom_indices = []
+    for atom in structure.topology.atoms():
+        if atom.residue.name == "BUT":
+            guest_atom_indices.append(atom.index)
+
+    host_guest_structure = Setup.prepare_complex_structure(
+        input_pdb,
+        guest_atom_indices,
+        ":BUT@C :BUT@C3",
+        24.0,
+        0,
+        46,
+    )
+    Setup.add_dummy_atoms_to_structure(
+        host_guest_structure,
+        [
+            np.array([0, 0, 0]),
+            np.array([0, 0, -3.0]),
+            np.array([0, 2.2, -5.2]),
+        ],
+        np.zeros(3),
+    )
+
+    # Distance restraint
+    rest1 = DAT_restraint()
+    rest1.continuous_apr = True
+    rest1.amber_index = True
+    rest1.topology = host_guest_structure
+    rest1.mask1 = ":DM1"
+    rest1.mask2 = ":BUT@C"
+    rest1.attach["target"] = 6.0
+    rest1.attach["fraction_list"] = [0.00, 0.04, 0.181, 0.496, 1.000]
+    rest1.attach["fc_final"] = 5.0
+    rest1.pull["fc"] = rest1.attach["fc_final"]
+    rest1.pull["target_initial"] = rest1.attach["target"]
+    rest1.pull["target_final"] = 24.0
+    rest1.pull["num_windows"] = 19
+    rest1.initialize()
+
+    # Angle 1 restraint
+    rest2 = DAT_restraint()
+    rest2.continuous_apr = True
+    rest2.amber_index = True
+    rest2.topology = input_pdb
+    rest2.mask1 = ":DM2"
+    rest2.mask2 = ":DM1"
+    rest2.mask3 = ":BUT@C"
+    rest2.attach["target"] = 180.0
+    rest2.attach["fraction_list"] = [0.00, 0.04, 0.181, 0.496, 1.000]
+    rest2.attach["fc_final"] = 100.0
+    rest2.pull["fc"] = rest2.attach["fc_final"]
+    rest2.pull["target_initial"] = rest2.attach["target"]
+    rest2.pull["target_final"] = rest2.attach["target"]
+    rest2.pull["num_windows"] = 19
+    rest2.initialize()
+
+    # Angle 2
+    rest3 = DAT_restraint()
+    rest3.continuous_apr = True
+    rest3.amber_index = True
+    rest3.topology = input_pdb
+    rest3.mask1 = ":DM1"
+    rest3.mask2 = ":BUT@C"
+    rest3.mask3 = ":BUT@C3"
+    rest3.attach["target"] = 180.0
+    rest3.attach["fraction_list"] = [0.00, 0.04, 0.181, 0.496, 1.000]
+    rest3.attach["fc_final"] = 100.0
+    rest3.pull["fc"] = rest2.attach["fc_final"]
+    rest3.pull["target_initial"] = rest2.attach["target"]
+    rest3.pull["target_final"] = rest2.attach["target"]
+    rest3.pull["num_windows"] = 19
+    rest3.initialize()
+
+    temperature = 298.15
+    guest_restraints = [rest1, rest2, rest3]
+    ref_state_work = Analyze.compute_ref_state_work(temperature, guest_restraints)
+    assert pytest.approx(ref_state_work, abs=1e-3) == -7.14151
+
+    fe_sym = Analyze.symmetry_correction(n_microstates=1, temperature=298.15)
+    assert fe_sym == 0.0
+    fe_sym = Analyze.symmetry_correction(n_microstates=2, temperature=298.15)
+    assert pytest.approx(fe_sym, abs=1e-3) == -0.410679
+
+
+def test_evaluator_gaff(clean_files):
+    temporary_directory = os.path.join(os.path.dirname(__file__), "tmp")
+
+    butane = os.path.join(os.path.dirname(__file__), "../data/cb6-but/but.mol2")
+    resname = "BUT"
+
+    gaff_version = "gaff"
+    generate_gaff(
+        butane,
+        resname,
+        output_name="but",
+        gaff_version=gaff_version,
+        directory_path=temporary_directory,
+    )
+
+    structure = pt.iterload(
+        os.path.join(temporary_directory, f"but.{gaff_version}.mol2")
+    )
+
+    butane_atom_type = [
+        "c3",
+        "hc",
+        "hc",
+        "hc",
+        "c3",
+        "hc",
+        "c3",
+        "hc",
+        "hc",
+        "hc",
+        "c3",
+        "hc",
+        "hc",
+        "hc",
+    ]
+    residue_names = []
+    for i, atom in enumerate(structure.topology.atoms):
+        if atom.resname not in residue_names:
+            residue_names.append(atom.resname)
+
+        assert atom.type == butane_atom_type[i]
+
+    assert len(residue_names) == 1
+    assert residue_names[0] == resname


### PR DESCRIPTION
This PR refactors the namespace for `Evaluator`-related modules to make the repository cleaner (preparing for a v1.1.0 release) so that instead of 
```python
from paprika.setup import Setup
from paprika.analyze import Analyze
```
we import the modules with
```python
from paprika.evaluator import Setup
from paprika.evaluator import Analyze
```

In addition, I separated the GAFF module from `setup.py` and added some tests. Other than that the code is basically the same.