### PR TITLE
Bump setup_miniconda to v2 so we don't have to allow unsafe GHA commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,13 @@ jobs:
         os: [macOS-latest, ubuntu-latest]
         python-version: [3.7]
     env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PYVER: ${{ matrix.python-version }}
       PACKAGE: paprika
 
     steps:
     - uses: actions/checkout@v2
 
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: paprika-dev


### PR DESCRIPTION
I just noticed this failing on one of my side projects too. Let's see if this fixes it. The OpenFF toolkit didn't have this problem, likely thanks to the very timely adoption of a bot that update GHA dependency versions (or just @mattwthompson's quick action) https://github.com/openforcefield/openforcefield/pull/767