### PR TITLE
Add Pint units to pAPRika

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ pAPRika utilizes `Pint` units through the `openff-units` wrapper. Any float valu
 
 If a `Pint` quantity is specified then the units will be converted accordingly to match the list above.
 
+```python
+from openff.units import unit
+```
+
 ## Initial Setup
 
 The very first step in the calculation is creating a coordinate file for the bound host-guest complex (we usually use PDB format for this part because it works well with `tleap`). This does not have to perfectly match the bound state by any means (we will later minimize and equilibrate), but this should be a reasonable illustration of the bound complex. This file can be created by hand (in a program like Chimera, VMD, or PyMOL) or by docking the guest into the host cavity (with MOE, AutoDock, DOCK, ...).
@@ -118,9 +122,7 @@ import parmed as pmd
 
 
 ```python
-structure = pmd.load_file("cb6-but/vac.prmtop",
-                          "cb6-but/vac.rst7",
-                          structure=True)
+structure = pmd.load_file("cb6-but/vac.prmtop", "cb6-but/vac.rst7", structure=True)
 ```
 
 
@@ -156,20 +158,19 @@ Note, these dummy atoms do not interact with the other atoms in the system, and 
 
 ```python
 from paprika.build import dummy
+
 ```
 
 
 ```python
-structure = pmd.load_file("cb6-but/aligned.prmtop",
-                          "cb6-but/aligned.rst7",
-                          structure=True)
+structure = pmd.load_file("cb6-but/aligned.prmtop", "cb6-but/aligned.rst7", structure=True)
 ```
 
 
 ```python
-structure = dummy.add_dummy(structure, residue_name="DM1", z=-6.0)
-structure = dummy.add_dummy(structure, residue_name="DM2", z=-9.0)
-structure = dummy.add_dummy(structure, residue_name="DM3", z=-11.2, y=2.2)
+structure = dummy.add_dummy(structure, residue_name="DM1", z=-6.0 * unit.angstrom)
+structure = dummy.add_dummy(structure, residue_name="DM2", z=-9.0 * unit.angstrom)
+structure = dummy.add_dummy(structure, residue_name="DM3", z=-11.2 * unit.angstrom, y=2.2 * unit.angstrom)
 ```
 
 
@@ -316,6 +317,8 @@ from paprika import restraints
 ```
 
 ```python
+k_dist = 5.0 * unit.kcal / unit.mole / unit.angstrom ** 2
+k_angle = 100.0 * unit.kcal / unit.mole / unit.radians ** 2
 static_restraints = []
 ```
 
@@ -332,7 +335,7 @@ structure = pmd.load_file("cb6-but/cb6-but-dum.prmtop",
 r = restraints.static_DAT_restraint(restraint_mask_list = [D1, H1],
                                     num_window_list = windows,
                                     ref_structure = structure,
-                                    force_constant = 5.0,
+                                    force_constant = k_dist,
                                     amber_index=True)
 
 static_restraints.append(r)
@@ -343,7 +346,7 @@ static_restraints.append(r)
 r = restraints.static_DAT_restraint(restraint_mask_list = [D2, D1, H1],
                                     num_window_list = windows,
                                     ref_structure = structure,
-                                    force_constant = 100.0,
+                                    force_constant = k_angle,
                                     amber_index=True)
 
 static_restraints.append(r)
@@ -354,7 +357,7 @@ static_restraints.append(r)
 r = restraints.static_DAT_restraint(restraint_mask_list = [D3, D2, D1, H1],
                                     num_window_list = windows,
                                     ref_structure = structure,
-                                    force_constant = 100.0,
+                                    force_constant = k_angle,
                                     amber_index=True)
 
 static_restraints.append(r)
@@ -369,7 +372,7 @@ The next three restraints control the orientation of the host relative to the du
 r = restraints.static_DAT_restraint(restraint_mask_list = [D1, H1, H2],
                                     num_window_list = windows,
                                     ref_structure = structure,
-                                    force_constant = 100.0,
+                                    force_constant = k_angle,
                                     amber_index=True)
 
 static_restraints.append(r)
@@ -380,7 +383,7 @@ static_restraints.append(r)
 r = restraints.static_DAT_restraint(restraint_mask_list = [D2, D1, H1, H2],
                                     num_window_list = windows,
                                     ref_structure = structure,
-                                    force_constant = 100.0,
+                                    force_constant = k_angle,
                                     amber_index=True)
 
 static_restraints.append(r)
@@ -391,7 +394,7 @@ static_restraints.append(r)
 r = restraints.static_DAT_restraint(restraint_mask_list = [D1, H1, H2, H3],
                                     num_window_list = windows,
                                     ref_structure = structure,
-                                    force_constant = 100.0,
+                                    force_constant = k_angle,
                                     amber_index=True)
 
 static_restraints.append(r)
@@ -427,11 +430,11 @@ r.auto_apr = True
 r.continuous_apr = True
 r.amber_index = True
 
-r.attach["target"] = 6.0                            # Angstroms
+r.attach["target"] = 6.0 * unit.angstrom            # Angstroms
 r.attach["fraction_list"] = attach_fractions
-r.attach["fc_final"] = 5.0                          # kcal/mol/Angstroms**2
+r.attach["fc_final"] = k_dist                       # kcal/mol/Angstroms**2
 
-r.pull["target_final"] = 24.0                       # Angstroms
+r.pull["target_final"] = 24.0 * unit.angstrom       # Angstroms
 r.pull["num_windows"] = windows[1]
 
 r.initialize()
@@ -449,11 +452,11 @@ r.auto_apr = True
 r.continuous_apr = True
 r.amber_index = True
 
-r.attach["target"] = 180.0                          # Degrees
+r.attach["target"] = 180.0 * unit.degrees           # Degrees
 r.attach["fraction_list"] = attach_fractions
-r.attach["fc_final"] = 100.0                        # kcal/mol/radian**2
+r.attach["fc_final"] = k_angle                      # kcal/mol/radian**2
 
-r.pull["target_final"] = 180.0                      # Degrees
+r.pull["target_final"] = 180.0 * unit.degrees       # Degrees
 r.pull["num_windows"] = windows[1]
 
 r.initialize()
@@ -471,11 +474,11 @@ r.auto_apr = True
 r.continuous_apr = True
 r.amber_index = True
 
-r.attach["target"] = 180.0                          # Degrees
+r.attach["target"] = 180.0 * unit.degrees           # Degrees
 r.attach["fraction_list"] = attach_fractions
-r.attach["fc_final"] = 100.0                        # kcal/mol/radian**2
+r.attach["fc_final"] = k_angle                      # kcal/mol/radian**2
 
-r.pull["target_final"] = 180.0                      # Degrees
+r.pull["target_final"] = 180.0 * unit.degrees       # Degrees
 r.pull["num_windows"] = windows[1]
 
 r.initialize()
@@ -493,7 +496,7 @@ from paprika.restraints import create_window_list
 
 window_list = create_window_list(guest_restraints)
 for window in window_list:
-    os.makedirs(f"windows/{window}")
+    os.makedirs(f"windows/{window}", exist_ok=True)
 ```
 
 ## Next, we ask pAPRika to write the restraint information in each window
@@ -506,9 +509,9 @@ The functional form of the restraints is specified in section 25.1 of the AMBER1
 ```python
 from paprika.restraints import amber_restraint_line
 
-host_guest_restraints = static_restraints + guest_restraints
+host_guest_restraints = (static_restraints + guest_restraints)
 for window in window_list:
-    with open(f"windows/{window}/disang.rest", "a") as file:
+    with open(f"windows/{window}/disang.rest", "w") as file:
         for restraint in host_guest_restraints:
             string = amber_restraint_line(restraint, window)
             if string is not None:
@@ -531,14 +534,16 @@ for window in window_list:
     if window[0] == "a":
         shutil.copy("cb6-but/cb6-but-dum.prmtop", f"windows/{window}/cb6-but-dum.prmtop")
         shutil.copy("cb6-but/cb6-but-dum.rst7", f"windows/{window}/cb6-but-dum.rst7")
+
     elif window[0] == "p":
-        structure = pmd.load_file("cb6-but/cb6-but-dum.prmtop", "cb6-but/cb6-but-dum.rst7",
-                          structure = True)
+        structure = pmd.load_file("cb6-but/cb6-but-dum.prmtop", "cb6-but/cb6-but-dum.rst7", structure = True)
         target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] - guest_restraints[0].pull['target_initial']
-        print(f"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.")
+
+        print(f"In window {window} we will translate the guest {target_difference:0.1f}.")
         for atom in structure.atoms:
             if atom.residue.name == "BUT":
-                atom.xz += target_difference
+                atom.xz += target_difference.magnitude
+
         structure.save(f"windows/{window}/cb6-but-dum.prmtop")
         structure.save(f"windows/{window}/cb6-but-dum.rst7")
 ```
@@ -604,9 +609,9 @@ for window in window_list:
     simulation.path = f"windows/{window}/"
     simulation.prefix = "minimize"
 
-    simulation.inpcrd = "cb6-but-dum.rst7"
-    simulation.ref = "cb6-but-dum.rst7"
     simulation.topology = "cb6-but-dum.prmtop"
+    simulation.coordinates = "cb6-but-dum.rst7"
+    simulation.ref = "cb6-but-dum.rst7"
     simulation.restraint_file = "disang.rest"
 
     simulation.config_gb_min()
@@ -694,9 +699,9 @@ for window in window_list:
     simulation.path = f"windows/{window}/"
     simulation.prefix = "production"
 
-    simulation.inpcrd = "minimize.rst7"
-    simulation.ref = "cb6-but-dum.rst7"
     simulation.topology = "cb6-but-dum.prmtop"
+    simulation.coordinates = "minimize.rst7"
+    simulation.ref = "cb6-but-dum.rst7"
     simulation.restraint_file = "disang.rest"
 
     simulation.config_gb_md()
@@ -790,7 +795,7 @@ from paprika import analysis
 
 ```python
 free_energy = analysis.fe_calc()
-free_energy.prmtop = "cb6-but-dum.prmtop"
+free_energy.topology = "cb6-but-dum.prmtop"
 free_energy.trajectory = 'production*.nc'
 free_energy.path = "windows"
 free_energy.restraint_list = guest_restraints
@@ -823,7 +828,7 @@ sem = np.sqrt(
 
 
 ```python
-print(f"The binding affinity for butane and cucurbit[6]uril = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol")
+print(f"The binding affinity for butane and cucurbit[6]uril = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol")
 ```
 
     The binding affinity for butane and cucurbit[6]uril = -9.00 +/- 5.53 kcal/mol

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,11 +12,14 @@ dependencies:
   - parmed
   - mdtraj
   - pymbar >=3.0.5
-  - openmm
+  - openmm >=7.5.0
+  - yank
   - ambertools >=20.0
   - pyyaml
   - plumed
   - intermol
+  - openff-units
+  - openff-utilities
 
   # devtools
   - isort

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,10 +22,10 @@ sys.path.insert(0, os.path.abspath("."))
 
 project = "pAPRika"
 copyright = (
-    "2020, Niel M. Henriksen, David R. Slochower, Simon Boothroyd, Jeffry Setiadi, and Willa Wang. "
+    "2021, Niel M. Henriksen, David R. Slochower, Simon Boothroyd, Jeffry Setiadi, Willa Wang and Matt Thompson. "
     "Project structure based on the Computational Molecular Science Python Cookiecutter version 1.0"
 )
-author = "Niel M. Henriksen, David R. Slochower, Simon Boothroyd, Jeffry Setiadi, and Willa Wang"
+author = "Niel M. Henriksen, David R. Slochower, Simon Boothroyd, Jeffry Setiadi, Willa Wang, and Matt Thompson"
 
 # The short X.Y version
 version = ""

--- a/docs/tutorials/01-tutorial-cb6-but.ipynb
+++ b/docs/tutorials/01-tutorial-cb6-but.ipynb
@@ -1007,10 +1007,10 @@
     "        structure = pmd.load_file(\"complex/cb6-but-dum.prmtop\", \"complex/cb6-but-dum.rst7\",\n",
     "                          structure = True)\n",
     "        target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] - guest_restraints[0].pull['target_initial']\n",
-    "        print(f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\")\n",
+    "        print(f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\")\n",
     "        for atom in structure.atoms:\n",
     "            if atom.residue.name == \"BUT\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "        structure.save(f\"windows/{window}/cb6-but-dum.prmtop\", overwrite=True)\n",
     "        structure.save(f\"windows/{window}/cb6-but-dum.rst7\", overwrite=True)"
    ]
@@ -1286,7 +1286,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
-    "free_energy.prmtop = \"cb6-but-dum.prmtop\"\n",
+    "free_energy.topology = \"cb6-but-dum.prmtop\"\n",
     "free_energy.trajectory = 'production*.nc'\n",
     "free_energy.path = \"windows\"\n",
     "free_energy.restraint_list = guest_restraints\n",
@@ -1350,7 +1350,7 @@
     }
    ],
    "source": [
-    "print(f\"The binding affinity for butane and cucurbit[6]uril = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol\")"
+    "print(f\"The binding affinity for butane and cucurbit[6]uril = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol\")"
    ]
   },
   {

--- a/docs/tutorials/02-tutorial-cb6-but-pbc.ipynb
+++ b/docs/tutorials/02-tutorial-cb6-but-pbc.ipynb
@@ -685,10 +685,10 @@
     "        structure = pmd.load_file(\"complex/cb6-but-dum.prmtop\", \"complex/cb6-but-dum.rst7\",\n",
     "                          structure = True)\n",
     "        target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] - guest_restraints[0].pull['target_initial']\n",
-    "        print(f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\")\n",
+    "        print(f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\")\n",
     "        for atom in structure.atoms:\n",
     "            if atom.residue.name == \"BUT\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "        structure.save(f\"windows/{window}/cb6-but-dum.prmtop\")\n",
     "        structure.save(f\"windows/{window}/cb6-but-dum.rst7\")"
    ]
@@ -1132,7 +1132,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
-    "free_energy.prmtop = \"cb6-but-dum-sol.prmtop\"\n",
+    "free_energy.topology = \"cb6-but-dum-sol.prmtop\"\n",
     "free_energy.trajectory = 'production*.nc'\n",
     "free_energy.path = \"windows\"\n",
     "free_energy.restraint_list = guest_restraints\n",

--- a/docs/tutorials/03-tutorial-k-cl.ipynb
+++ b/docs/tutorials/03-tutorial-k-cl.ipynb
@@ -302,11 +302,11 @@
     "            - restraint.phase[\"pull\"][\"targets\"][0]\n",
     "        )\n",
     "        print(\n",
-    "            f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\"\n",
+    "            f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\"\n",
     "        )\n",
     "        for atom in structure.atoms:\n",
     "            if atom.name == \"Cl-\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "        structure.save(f\"tmp/windows/{window}/k-cl.prmtop\", overwrite=True)\n",
     "        structure.save(f\"tmp/windows/{window}/k-cl.rst7\", overwrite=True)"
    ]
@@ -538,9 +538,9 @@
     "    simulation.path = f\"tmp/windows/{window}/\"\n",
     "    simulation.prefix = \"production\"\n",
     "\n",
-    "    simulation.inpcrd = \"minimize.rst7\"\n",
-    "    simulation.ref = \"k-cl-sol.rst7\"\n",
     "    simulation.topology = \"k-cl-sol.prmtop\"\n",
+    "    simulation.coordinate = \"minimize.rst7\"\n",
+    "    simulation.ref = \"k-cl-sol.rst7\"\n",
     "    simulation.restraint_file = \"disang.rest\"\n",
     "\n",
     "    simulation.config_pbc_md()\n",
@@ -582,7 +582,7 @@
    "outputs": [],
    "source": [
     "free_energy = fe_calc()\n",
-    "free_energy.prmtop = \"k-cl-sol.prmtop\"\n",
+    "free_energy.topology = \"k-cl-sol.prmtop\"\n",
     "free_energy.trajectory = \"production*.nc\"\n",
     "free_energy.path = \"tmp/windows\"\n",
     "free_energy.restraint_list = [restraint]\n",
@@ -631,7 +631,7 @@
     ")\n",
     "\n",
     "print(\n",
-    "    f\"The binding affinity for K+ (+1.3) and Cl- (-1.3) = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol\"\n",
+    "    f\"The binding affinity for K+ (+1.3) and Cl- (-1.3) = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol\"\n",
     ")"
    ]
   }

--- a/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
+++ b/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
@@ -569,11 +569,11 @@
     "        )\n",
     "        target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] -\\\n",
     "                            guest_restraints[0].pull['target_initial']\n",
-    "        logging.info(f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\")\n",
+    "        logging.info(f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\")\n",
     "        \n",
     "        for atom in structure.atoms:\n",
     "            if atom.residue.name == \"BUT\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "                \n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.prmtop\"), overwrite=True)\n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.rst7\"), overwrite=True)"
@@ -921,7 +921,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
-    "free_energy.prmtop = \"system.pdb\"\n",
+    "free_energy.topology = \"system.pdb\"\n",
     "free_energy.trajectory = \"production.dcd\"\n",
     "free_energy.path = work_dir\n",
     "free_energy.restraint_list = guest_restraints\n",
@@ -969,7 +969,7 @@
     }
    ],
    "source": [
-    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol\")"
+    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol\")"
    ]
   },
   {

--- a/docs/tutorials/05-tutorial-cb6-but-plumed.ipynb
+++ b/docs/tutorials/05-tutorial-cb6-but-plumed.ipynb
@@ -657,11 +657,11 @@
     "        )\n",
     "        target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] -\\\n",
     "                            guest_restraints[0].pull['target_initial']\n",
-    "        print(f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\")\n",
+    "        print(f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\")\n",
     "        \n",
     "        for atom in structure.atoms:\n",
     "            if atom.residue.name == \"BUT\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "                \n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.prmtop\"), overwrite=True)\n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.rst7\"), overwrite=True)"
@@ -909,7 +909,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
-    "free_energy.prmtop = \"cb6-but-dum.prmtop\"\n",
+    "free_energy.topology = \"cb6-but-dum.prmtop\"\n",
     "free_energy.trajectory = 'production*.nc'\n",
     "free_energy.path = work_dir\n",
     "free_energy.restraint_list = guest_restraints\n",
@@ -978,7 +978,7 @@
     }
    ],
    "source": [
-    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol\")"
+    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol\")"
    ]
   }
  ],

--- a/docs/tutorials/06-tutorial-cb6-but-gromacs.ipynb
+++ b/docs/tutorials/06-tutorial-cb6-but-gromacs.ipynb
@@ -665,11 +665,11 @@
     "        )\n",
     "        target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] -\\\n",
     "                            guest_restraints[0].pull['target_initial']\n",
-    "        print(f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\")\n",
+    "        print(f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\")\n",
     "        \n",
     "        for atom in structure.atoms:\n",
     "            if atom.residue.name == \"BUT\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "                \n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.prmtop\"), overwrite=True)\n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.rst7\"), overwrite=True)"
@@ -1113,7 +1113,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
-    "free_energy.prmtop = \"cb6-but-dum-sol.pdb\"\n",
+    "free_energy.topology = \"cb6-but-dum-sol.pdb\"\n",
     "free_energy.trajectory = 'production*.trr'\n",
     "free_energy.path = work_dir\n",
     "free_energy.restraint_list = guest_restraints\n",
@@ -1182,7 +1182,7 @@
     }
    ],
    "source": [
-    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol\")"
+    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol\")"
    ]
   }
  ],

--- a/docs/tutorials/07-tutorial-cb6-but-namd.ipynb
+++ b/docs/tutorials/07-tutorial-cb6-but-namd.ipynb
@@ -617,11 +617,11 @@
     "        )\n",
     "        target_difference = guest_restraints[0].phase['pull']['targets'][int(window[1:])] -\\\n",
     "                            guest_restraints[0].pull['target_initial']\n",
-    "        print(f\"In window {window} we will translate the guest {target_difference:0.1f} Angstroms.\")\n",
+    "        print(f\"In window {window} we will translate the guest {target_difference.magnitude:0.1f}.\")\n",
     "        \n",
     "        for atom in structure.atoms:\n",
     "            if atom.residue.name == \"BUT\":\n",
-    "                atom.xz += target_difference\n",
+    "                atom.xz += target_difference.magnitude\n",
     "                \n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.prmtop\"), overwrite=True)\n",
     "        structure.save(os.path.join(work_dir, window, f\"{base_name}.rst7\"), overwrite=True)"
@@ -993,7 +993,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
-    "free_energy.prmtop = \"cb6-but-dum.prmtop\"\n",
+    "free_energy.topology = \"cb6-but-dum.prmtop\"\n",
     "free_energy.trajectory = 'production*.dcd'\n",
     "free_energy.path = work_dir\n",
     "free_energy.restraint_list = guest_restraints\n",
@@ -1062,7 +1062,7 @@
     }
    ],
    "source": [
-    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity:0.2f} +/- {sem:0.2f} kcal/mol\")"
+    "print(f\"The binding affinity of butane to cucurbit[6]uril = {binding_affinity.magnitude:0.2f} +/- {sem.magnitude:0.2f} kcal/mol\")"
    ]
   }
  ],

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -1079,8 +1079,9 @@ class fe_calc(object):
             else:
                 total_sem_matrix = self.results[phase][method]["fraction_sem_matrix"][
                     max_fraction
-                ]
+                ].magnitude
             self.results[phase][method]["roi"] = np.zeros([num_win], np.float64)
+
             for k in range(num_win):
                 # Compute overall integrated SEM with 10% smaller SEM for dU[k]
                 cnvg_dU_samples = np.array(dU_samples)
@@ -1207,8 +1208,9 @@ class fe_calc(object):
                     # Store convergence values, which are helpful for running
                     # simulations
                     windows = len(self.results[phase][method]["sem_matrix"])
-                    self.results[phase][method]["largest_neighbor"] = (
-                        np.ones([windows], np.float64) * -1.0
+                    self.results[phase][method]["largest_neighbor"] = unit.Quantity(
+                        np.ones([windows], np.float64) * -1.0,
+                        units=self.energy_unit,
                     )
                     logger.info(f"{phase}: computing largest_neighbor for {method}...")
 

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -40,7 +40,7 @@ class fe_calc(object):
 
     @property
     def temperature(self):
-        """float: The temperature used during the simulation. This will update β (1/kT) as well."""
+        """float or unit.Quantity: The temperature used during the simulation. This will update β (1/kT) as well."""
         return self._temperature
 
     @temperature.setter
@@ -341,6 +341,7 @@ class fe_calc(object):
 
     @property
     def energy_unit(self):
+        """pint.unit: The based unit for energy."""
         return self._energy_unit
 
     @energy_unit.setter
@@ -349,6 +350,7 @@ class fe_calc(object):
 
     @property
     def distance_unit(self):
+        """pint.unit: The base unit for distance."""
         return self._distance_unit
 
     @distance_unit.setter
@@ -357,6 +359,7 @@ class fe_calc(object):
 
     @property
     def angle_unit(self):
+        """pint.unit: The base unit for angles."""
         return self._angle_unit
 
     @angle_unit.setter
@@ -365,6 +368,7 @@ class fe_calc(object):
 
     @property
     def temperature_unit(self):
+        """pint.unit: The base unit for temperature."""
         return self._temperature_unit
 
     @temperature_unit.setter

--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -2,6 +2,8 @@ import logging
 
 import numpy as np
 import parmed as pmd
+from openff.units import unit
+from paprika.utils import check_unit
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +169,7 @@ def rotate_around_axis(structure, axis, angle):
         Molecular structure containing coordinates.
     axis: str or list or :class:`numpy.ndarray`
         The axis of rotation. If an array is specified, the axis-vector will be normalized automatically.
-    angle: float
+    angle: float or unit.Quantity
         The angle of rotation in degrees.
 
     Returns
@@ -188,7 +190,7 @@ def rotate_around_axis(structure, axis, angle):
     axis = _return_array(axis)
 
     # Convert angle to radians (temporary until Pint integration)
-    angle *= np.pi / 180.0
+    angle = check_unit(angle, base_unit=unit.radians).to(unit.radians).magnitude
 
     if np.array_equal(axis, np.array([1.0, 0.0, 0.0])):
         rotation_matrix = np.array(
@@ -298,7 +300,7 @@ def get_theta(structure, mask1, mask2, axis):
         np.dot(vector, axis) / (np.linalg.norm(vector) * np.linalg.norm(axis))
     )
 
-    return theta
+    return unit.Quantity(theta, units=unit.radians)
 
 
 def get_rotation_matrix(vector, ref_vector):
@@ -429,7 +431,7 @@ def offset_structure(structure, offset, dimension=None):
     ----------
     structure : :class:`parmed.Structure`
         Molecular structure containing coordinates.
-    offset : float or :class:`numpy.ndarray`
+    offset : float or :class:`numpy.ndarray` or unit.Quantity
         The offset that will be added to *every* atom in the structure.
     dimension : str or list or :class:`numpy.ndarray`, optional, default=None
         By default the structure will be moved by ``offset`` in all direction if it is a single number, i.e. ``xyz +
@@ -459,7 +461,9 @@ def offset_structure(structure, offset, dimension=None):
     else:
         mask = _return_array(dimension)
 
+    offset = check_unit(offset, base_unit=unit.angstrom)
     offset *= mask
+    offset = offset.to(unit.angstrom).magnitude
 
     # Offset coordinates
     offset_coords = np.empty_like(structure.coordinates)

--- a/paprika/build/dummy.py
+++ b/paprika/build/dummy.py
@@ -4,17 +4,19 @@ import parmed as pmd
 from parmed.structure import Structure as ParmedStructureClass
 
 from paprika import utils
+from paprika.utils import check_unit
+from openff.units import unit
 
 
 def add_dummy(
     structure,
     atom_name="DUM",
     residue_name="DUM",
-    mass=208.00,
+    mass=208.00 * unit.dalton,
     atomic_number=82,
-    x=0.000,
-    y=0.000,
-    z=0.000,
+    x=0.000 * unit.angstrom,
+    y=0.000 * unit.angstrom,
+    z=0.000 * unit.angstrom,
 ):
     """Add a dummy atom at the specified coordinates to the end of a structure.
 
@@ -44,6 +46,11 @@ def add_dummy(
 
     """
 
+    mass = check_unit(mass, base_unit=unit.dalton)
+    x = check_unit(x, base_unit=unit.angstrom)
+    y = check_unit(y, base_unit=unit.angstrom)
+    z = check_unit(z, base_unit=unit.angstrom)
+
     if isinstance(structure, str):
         structure = utils.return_parmed_structure(structure)
     elif isinstance(structure, ParmedStructureClass):
@@ -57,14 +64,14 @@ def add_dummy(
     # Create an atom object
     dum = pmd.topologyobjects.Atom()
     dum.name = atom_name
-    dum.mass = mass
+    dum.mass = mass.to(unit.dalton).magnitude
     dum.atomic_number = atomic_number
     # This may be a problem if these coordinates are outside the periodic box
     # dimensions and ParmEd does not recalculate the box vectors before saving
     # `inpcrd`...
-    dum.xx = x
-    dum.xy = y
-    dum.xz = z
+    dum.xx = x.to(unit.angstrom).magnitude
+    dum.xy = y.to(unit.angstrom).magnitude
+    dum.xz = z.to(unit.angstrom).magnitude
 
     # Assume that the last atom in the structure has the highest atom index,
     # so the new atom will be at the end.

--- a/paprika/evaluator/analyze.py
+++ b/paprika/evaluator/analyze.py
@@ -58,7 +58,7 @@ class Analyze:
         """
         analysis = fe_calc()
 
-        analysis.prmtop = topology_name
+        analysis.topology = topology_name
         analysis.trajectory = trajectory_mask
         analysis.path = windows_directory
 
@@ -67,7 +67,7 @@ class Analyze:
         analysis.methods = [analysis_method]
         analysis.bootcycles = bootstrap_cycles
 
-        analysis.collect_data(single_prmtop=False)
+        analysis.collect_data(single_topology=False)
         analysis.compute_free_energy(phases=[phase])
 
         return analysis.results

--- a/paprika/io.py
+++ b/paprika/io.py
@@ -141,9 +141,9 @@ class PaprikaDecoder(json.JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(self, object_hook=self.custom_object_hook, *args, **kwargs)
 
-    def object_hook(self, obj):
+    def custom_object_hook(self, obj):
         if "__ndarray__" in obj:
             data = base64.b64decode(obj["__ndarray__"])
             return np.frombuffer(data, obj["dtype"]).reshape(obj["shape"])

--- a/paprika/io.py
+++ b/paprika/io.py
@@ -141,7 +141,9 @@ class PaprikaDecoder(json.JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.custom_object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(
+            self, object_hook=self.custom_object_hook, *args, **kwargs
+        )
 
     def custom_object_hook(self, obj):
         if "__ndarray__" in obj:

--- a/paprika/restraints/openmm.py
+++ b/paprika/restraints/openmm.py
@@ -5,6 +5,7 @@ import numpy as np
 import parmed as pmd
 import simtk.openmm as openmm
 import simtk.unit as simtk_unit
+from openff.units import unit
 from openff.units.simtk import to_simtk
 
 logger = logging.getLogger(__name__)
@@ -28,8 +29,8 @@ def apply_positional_restraints(
         The system object to add the positional restraints to.
     force_group : int, optional
         The force group to add the positional restraints to.
-    kpos : float, optional
-        The force constant for restraining the dummy atoms (kcal/mol/Å^2).
+    kpos : float, simkt.unit.Quantity or pint.unit.Quantity, optional
+        The force constant for restraining the dummy atoms (kcal/mol/Å^2 if float).
     """
 
     # noinspection PyTypeChecker
@@ -50,7 +51,12 @@ def apply_positional_restraints(
             # ParmEd correctly reports `atom.positions` as units of Ångstroms.
             # But then we can't access atom indices. Using `atom.xx` works for
             # coordinates, but is unitless.
-            k = kpos * simtk_unit.kilocalories_per_mole / simtk_unit.angstroms ** 2
+            if isinstance(kpos, float):
+                k = kpos * simtk_unit.kilocalories_per_mole / simtk_unit.angstroms ** 2
+            elif isinstance(kpos, simtk_unit.Quantity):
+                k = kpos
+            elif isinstance(kpos, unit.Quantity):
+                k = to_simtk(kpos)
 
             x0 = 0.1 * atom.xx * simtk_unit.nanometers
             y0 = 0.1 * atom.xy * simtk_unit.nanometers

--- a/paprika/restraints/plumed.py
+++ b/paprika/restraints/plumed.py
@@ -276,7 +276,8 @@ class Plumed:
                     cv_key = get_key(cv_dict, atom_string)[0]
 
                     bias_lines.append(
-                        f"{bias_type.upper()} ARG={cv_key} AT={target:.4f} KAPPA={force_constant:.2f}\n"
+                        f"{bias_type.upper()} ARG={cv_key} AT={target.magnitude:.4f} KAPPA="
+                        f"{force_constant.magnitude:.2f}\n"
                     )
 
                 # Increment cv index

--- a/paprika/restraints/utils.py
+++ b/paprika/restraints/utils.py
@@ -61,14 +61,6 @@ def get_restraint_values(restraint, phase, window_number):
         Dictionary containing the Amber NMR-style values
 
     """
-    # Unit type
-    energy_unit = unit.kcal / unit.mole
-    target_unit = (
-        unit.angstrom if restraint.restraint_type == "distance" else unit.degrees
-    )
-    force_constant_unit = energy_unit / target_unit ** 2
-    if not restraint.restraint_type == "distance":
-        force_constant_unit = energy_unit / unit.radians ** 2
 
     # Amber NMR bounds
     lower_bound = 0.0 * unit.angstrom
@@ -87,23 +79,18 @@ def get_restraint_values(restraint, phase, window_number):
         )
 
     restraint_values = {
-        "r1": lower_bound.to(target_unit).magnitude,
-        "r2": restraint.phase[phase]["targets"][window_number]
-        .to(target_unit)
-        .magnitude,
-        "r3": restraint.phase[phase]["targets"][window_number]
-        .to(target_unit)
-        .magnitude,
-        "r4": upper_bound.to(target_unit).magnitude,
-        "rk2": restraint.phase[phase]["force_constants"][window_number]
-        .to(force_constant_unit)
-        .magnitude,
-        "rk3": restraint.phase[phase]["force_constants"][window_number]
-        .to(force_constant_unit)
-        .magnitude,
+        "r1": lower_bound,
+        "r2": restraint.phase[phase]["targets"][window_number],
+        "r3": restraint.phase[phase]["targets"][window_number],
+        "r4": upper_bound,
+        "rk2": restraint.phase[phase]["force_constants"][window_number],
+        "rk3": restraint.phase[phase]["force_constants"][window_number],
     }
+    print(restraint_values)
 
     override_dict(restraint_values, restraint.custom_restraint_values)
+
+    print(restraint_values)
 
     return restraint_values
 

--- a/paprika/tests/test_align.py
+++ b/paprika/tests/test_align.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 import parmed as pmd
 import pytest
+from openff.units import unit
 
 from paprika.build.align import (
     align_principal_axes,
@@ -21,7 +22,7 @@ from paprika.build.align import (
 
 
 def test_center_mask():
-    """ Test that the first mask is centered """
+    """Test that the first mask is centered."""
     cb6 = pmd.load_file(
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb")
     )
@@ -31,7 +32,7 @@ def test_center_mask():
 
 
 def test_alignment_after_offset():
-    """ Test that molecule is properly aligned after random offset. """
+    """Test that molecule is properly aligned after random offset."""
     cb6 = pmd.load_file(
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb")
     )
@@ -43,7 +44,7 @@ def test_alignment_after_offset():
 
 
 def test_theta_after_alignment():
-    """ Test that molecule is properly aligned after random offset. """
+    """Test that molecule is properly aligned after random offset."""
     cb6 = pmd.load_file(
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb")
     )
@@ -60,7 +61,7 @@ def test_theta_after_alignment():
 
 
 def test_translate_to_origin():
-    """ Test that molecule is properly aligned after translated to the origin."""
+    """Test that molecule is properly aligned after translated to the origin."""
     cb6 = pmd.load_file(
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb"),
         structure=True,
@@ -136,16 +137,22 @@ def test_rotate_around_axis():
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"),
         structure=True,
     )
-    cb6_aligned = rotate_around_axis(cb6, axis="z", angle=90.0)
-    angle = get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="z") * 180 / np.pi
+    cb6_aligned = rotate_around_axis(cb6, axis="z", angle=90.0 * unit.degrees)
+    angle = (
+        get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="z").to(unit.degrees).magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 0.0
 
-    cb6_aligned = rotate_around_axis(cb6_aligned, axis="x", angle=90.0)
-    angle = get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="x") * 180 / np.pi
+    cb6_aligned = rotate_around_axis(cb6_aligned, axis="x", angle=90.0 * unit.degrees)
+    angle = (
+        get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="x").to(unit.degrees).magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 90.0
 
-    cb6_aligned = rotate_around_axis(cb6_aligned, axis="y", angle=90.0)
-    angle = get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="y") * 180 / np.pi
+    cb6_aligned = rotate_around_axis(cb6_aligned, axis="y", angle=90.0) * unit.degrees
+    angle = (
+        get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="y").to(unit.degrees).magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 180.0
 
     # Arbitrary axes
@@ -153,12 +160,20 @@ def test_rotate_around_axis():
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"),
         structure=True,
     )
-    cb6_axis = rotate_around_axis(cb6, axis=[0, 0, 1], angle=90.0)
-    angle = get_theta(cb6_axis, ":BUT@C", ":BUT@C3", axis=[0, 0, 1]) * 180 / np.pi
+    cb6_axis = rotate_around_axis(cb6, axis=[0, 0, 1], angle=90.0 * unit.degrees)
+    angle = (
+        get_theta(cb6_axis, ":BUT@C", ":BUT@C3", axis=[0, 0, 1])
+        .to(unit.degrees)
+        .magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 0.0
 
-    cb6_axis = rotate_around_axis(cb6, axis=[1, 1, 1], angle=90.0)
-    angle = get_theta(cb6_axis, ":BUT@C", ":BUT@C3", axis=[1, 1, 1]) * 180 / np.pi
+    cb6_axis = rotate_around_axis(cb6, axis=[1, 1, 1], angle=90.0 * unit.degrees)
+    angle = (
+        get_theta(cb6_axis, ":BUT@C", ":BUT@C3", axis=[1, 1, 1])
+        .to(unit.degrees)
+        .magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 54.7
 
 

--- a/paprika/tests/test_align.py
+++ b/paprika/tests/test_align.py
@@ -49,13 +49,21 @@ def test_theta_after_alignment():
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.pdb")
     )
     aligned_cb6 = zalign(cb6, ":CB6", ":BUT")
-    assert get_theta(aligned_cb6, ":CB6", ":BUT", axis="z") == 0
     assert (
-        pytest.approx(get_theta(aligned_cb6, ":CB6", ":BUT", axis="x"), abs=1e-3)
+        get_theta(aligned_cb6, ":CB6", ":BUT", axis="z").to(unit.radians).magnitude == 0
+    )
+    assert (
+        pytest.approx(
+            get_theta(aligned_cb6, ":CB6", ":BUT", axis="x").to(unit.radians).magnitude,
+            abs=1e-3,
+        )
         == 1.5708
     )
     assert (
-        pytest.approx(get_theta(aligned_cb6, ":CB6", ":BUT", axis="y"), abs=1e-3)
+        pytest.approx(
+            get_theta(aligned_cb6, ":CB6", ":BUT", axis="y").to(unit.radians).magnitude,
+            abs=1e-3,
+        )
         == 1.5708
     )
 
@@ -121,13 +129,19 @@ def test_align_principal_axes():
         cb6, atom_mask=":CB6", principal_axis=1, axis="y"
     )
 
-    angle = get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="z") * 180 / np.pi
+    angle = (
+        get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="z").to(unit.degrees).magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 90.0
 
-    angle = get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="y") * 180 / np.pi
+    angle = (
+        get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="y").to(unit.degrees).magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 0.0
 
-    angle = get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="x") * 180 / np.pi
+    angle = (
+        get_theta(cb6_aligned, ":BUT@C", ":BUT@C3", axis="x").to(unit.degrees).magnitude
+    )
     assert pytest.approx(angle, abs=1e-1) == 90.0
 
 

--- a/paprika/tests/test_analysis.py
+++ b/paprika/tests/test_analysis.py
@@ -87,7 +87,7 @@ def setup_free_energy_calculation():
     seed = 12345
 
     fecalc = analysis.fe_calc()
-    fecalc.prmtop = os.path.join(
+    fecalc.topology = os.path.join(
         os.path.dirname(__file__), "../data/cb6-but-apr/vac.prmtop"
     )
     fecalc.trajectory = "*.nc"
@@ -115,10 +115,10 @@ def test_mbar_block(clean_files, setup_free_energy_calculation):
 
     # Test mbar-block free energies and uncertainties
     test_vals = [
-        results["attach"][method]["fe"],
-        results["attach"][method]["sem"],
-        results["pull"][method]["fe"],
-        results["pull"][method]["sem"],
+        results["attach"][method]["fe"].magnitude,
+        results["attach"][method]["sem"].magnitude,
+        results["pull"][method]["fe"].magnitude,
+        results["pull"][method]["sem"].magnitude,
     ]
     reference_values = [13.267731176, 0.16892084090, -2.1791430735, 0.93638948302]
     assert reference_values == approx(test_vals, abs=0.01)
@@ -163,10 +163,10 @@ def test_ti_block(clean_files, setup_free_energy_calculation):
 
     # Test ti-block free energies and uncertainties
     test_vals = [
-        results["attach"][method]["fe"],
-        results["attach"][method]["sem"],
-        results["pull"][method]["fe"],
-        results["pull"][method]["sem"],
+        results["attach"][method]["fe"].magnitude,
+        results["attach"][method]["sem"].magnitude,
+        results["pull"][method]["fe"].magnitude,
+        results["pull"][method]["sem"].magnitude,
     ]
     reference_values = np.array([13.35, 0.26, -1.85, 0.78])
     assert reference_values == approx(test_vals, abs=0.01)
@@ -271,16 +271,22 @@ def test_temperature(clean_files):
     fecalc.temperature = 298.15
     assert pytest.approx(fecalc.beta.magnitude, abs=1e-3) == 1.68780
     fecalc.compute_ref_state_work([rest1, rest2, None, None, rest3, None])
-    assert pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -7.14151
+    assert (
+        pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -7.14151
+    )
 
     fecalc = analysis.fe_calc()
     fecalc.temperature = 328.15
     assert pytest.approx(fecalc.beta.magnitude, abs=1e-3) == 1.53285
     fecalc.compute_ref_state_work([rest1, rest2, None, None, rest3, None])
-    assert pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -7.70392
+    assert (
+        pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -7.70392
+    )
 
     fecalc = analysis.fe_calc()
     fecalc.temperature = 278.15
     assert pytest.approx(fecalc.beta.magnitude, abs=1e-3) == 1.80839
     fecalc.compute_ref_state_work([rest1, rest2, None, None, rest3, None])
-    assert pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -6.75834
+    assert (
+        pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -6.75834
+    )

--- a/paprika/tests/test_analysis.py
+++ b/paprika/tests/test_analysis.py
@@ -98,7 +98,7 @@ def setup_free_energy_calculation():
     fecalc.ti_matrix = "diagonal"
     fecalc.compute_largest_neighbor = True
     fecalc.compute_roi = True
-    fecalc.collect_data(single_prmtop=True)
+    fecalc.collect_data(single_topology=True)
     fecalc.compute_free_energy(seed=seed)
     fecalc.compute_ref_state_work([rest1, rest2, rest3, None, None, None])
 
@@ -209,7 +209,7 @@ def test_ti_block(clean_files, setup_free_energy_calculation):
 
 def test_reference_state_work(clean_files, setup_free_energy_calculation):
     results = setup_free_energy_calculation.results
-    assert np.isclose(-4.34372240, results["ref_state_work"])
+    assert np.isclose(-4.34372240, results["ref_state_work"].magnitude)
 
 
 def test_temperature(clean_files):
@@ -269,18 +269,18 @@ def test_temperature(clean_files):
 
     fecalc = analysis.fe_calc()
     fecalc.temperature = 298.15
-    assert pytest.approx(fecalc.beta, abs=1e-3) == 1.68780
+    assert pytest.approx(fecalc.beta.magnitude, abs=1e-3) == 1.68780
     fecalc.compute_ref_state_work([rest1, rest2, None, None, rest3, None])
-    assert pytest.approx(fecalc.results["ref_state_work"], abs=1e-3) == -7.14151
+    assert pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -7.14151
 
     fecalc = analysis.fe_calc()
     fecalc.temperature = 328.15
-    assert pytest.approx(fecalc.beta, abs=1e-3) == 1.53285
+    assert pytest.approx(fecalc.beta.magnitude, abs=1e-3) == 1.53285
     fecalc.compute_ref_state_work([rest1, rest2, None, None, rest3, None])
-    assert pytest.approx(fecalc.results["ref_state_work"], abs=1e-3) == -7.70392
+    assert pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -7.70392
 
     fecalc = analysis.fe_calc()
     fecalc.temperature = 278.15
-    assert pytest.approx(fecalc.beta, abs=1e-3) == 1.80839
+    assert pytest.approx(fecalc.beta.magnitude, abs=1e-3) == 1.80839
     fecalc.compute_ref_state_work([rest1, rest2, None, None, rest3, None])
-    assert pytest.approx(fecalc.results["ref_state_work"], abs=1e-3) == -6.75834
+    assert pytest.approx(fecalc.results["ref_state_work"].magnitude, abs=1e-3) == -6.75834

--- a/paprika/tests/test_analysis.py
+++ b/paprika/tests/test_analysis.py
@@ -124,12 +124,12 @@ def test_mbar_block(clean_files, setup_free_energy_calculation):
     assert reference_values == approx(test_vals, abs=0.01)
 
     # Test attach mbar-block largest_neighbor values
-    test_vals = results["attach"][method]["largest_neighbor"]
+    test_vals = results["attach"][method]["largest_neighbor"].magnitude
     reference_values = np.array([0.0198918, 0.0451676, 0.0564517, 0.1079282, 0.1079282])
     assert reference_values == approx(test_vals, abs=0.01)
 
     # Test pull mbar-block largest_neighbor values
-    test_vals = results["pull"][method]["largest_neighbor"]
+    test_vals = results["pull"][method]["largest_neighbor"].magnitude
     reference_values = np.array(
         [
             0.2053769,
@@ -174,12 +174,12 @@ def test_ti_block(clean_files, setup_free_energy_calculation):
     # ROI only runs during TI.
 
     # Test attach ti-block largest_neighbor values
-    test_vals = results["attach"][method]["largest_neighbor"]
+    test_vals = results["attach"][method]["largest_neighbor"].magnitude
     reference_values = np.array([0.03, 0.07, 0.10, 0.18, 0.18])
     assert reference_values == approx(test_vals, abs=0.01)
 
     # Test pull ti-block largest_neighbor values
-    test_vals = results["pull"][method]["largest_neighbor"]
+    test_vals = results["pull"][method]["largest_neighbor"].magnitude
 
     reference_values = np.array(
         [

--- a/paprika/tests/test_dummy.py
+++ b/paprika/tests/test_dummy.py
@@ -31,7 +31,7 @@ def clean_files(directory=os.path.join(os.path.dirname(__file__), "tmp")):
 
 
 def test_add_dummy(clean_files):
-    """ Test that dummy atoms get added correctly """
+    """Test that dummy atoms get added correctly"""
     temporary_directory = os.path.join(os.path.dirname(__file__), "tmp")
     host_guest = pmd.load_file(
         os.path.join(

--- a/paprika/tests/test_evaluator.py
+++ b/paprika/tests/test_evaluator.py
@@ -9,6 +9,7 @@ import numpy as np
 import parmed as pmd
 import pytest
 import pytraj as pt
+from openff.units import unit
 
 from paprika.evaluator import Analyze, Setup
 from paprika.evaluator.amber import generate_gaff
@@ -200,7 +201,10 @@ def test_evaluator_analyze(clean_files):
     temperature = 298.15
     guest_restraints = [rest1, rest2, rest3]
     ref_state_work = Analyze.compute_ref_state_work(temperature, guest_restraints)
-    assert pytest.approx(ref_state_work, abs=1e-3) == -7.14151
+    assert (
+        pytest.approx(ref_state_work.to(unit.kcal / unit.mole).magnitude, abs=1e-3)
+        == -7.14151
+    )
 
     fe_sym = Analyze.symmetry_correction(n_microstates=1, temperature=298.15)
     assert fe_sym == 0.0

--- a/paprika/tests/test_io.py
+++ b/paprika/tests/test_io.py
@@ -22,7 +22,7 @@ def clean_files(directory="tmp"):
 
 
 def test_save_and_load_single_restraint(clean_files):
-    """ Test we can save a simple restraint """
+    """Test we can save a simple restraint"""
     rest = DAT_restraint()
     rest.amber_index = True
     rest.continuous_apr = False
@@ -51,7 +51,7 @@ def test_save_and_load_single_restraint(clean_files):
 
 
 def test_save_and_load_list_restraint(clean_files):
-    """ Test we can save and load a list of restraints """
+    """Test we can save and load a list of restraints"""
     rest1 = DAT_restraint()
     rest1.amber_index = True
     rest1.continuous_apr = False

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 import parmed as pmd
 import pytest
+from openff.units import unit
 
 from paprika.restraints.restraints import DAT_restraint, create_window_list
 from paprika.restraints.utils import (
@@ -44,23 +45,36 @@ def test_DAT_restraint():
     rest1.release["fc_initial"] = rest1.attach["fc_initial"]
     rest1.release["fc_final"] = rest1.attach["fc_final"]
     rest1.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / target_units ** 2
     assert rest1.index1 == [13, 31, 49, 67, 85, 103]
     assert rest1.index2 == [119]
     assert rest1.index3 is None
     assert rest1.index4 is None
     assert np.allclose(
-        rest1.phase["attach"]["force_constants"], np.array([0.0, 1.0, 2.0, 3.0])
-    )
-    assert np.allclose(rest1.phase["attach"]["targets"], np.array([3.0, 3.0, 3.0, 3.0]))
-    assert np.allclose(
-        rest1.phase["pull"]["force_constants"], np.array([3.0, 3.0, 3.0, 3.0])
-    )
-    assert np.allclose(rest1.phase["pull"]["targets"], np.array([3.0, 4.0, 5.0, 6.0]))
-    assert np.allclose(
-        rest1.phase["release"]["force_constants"], np.array([0.0, 1.0, 2.0, 3.0])
+        rest1.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.0, 2.0, 3.0]),
     )
     assert np.allclose(
-        rest1.phase["release"]["targets"], np.array([6.0, 6.0, 6.0, 6.0])
+        rest1.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([3.0, 3.0, 3.0, 3.0]),
+    )
+    assert np.allclose(
+        rest1.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([3.0, 3.0, 3.0, 3.0]),
+    )
+    assert np.allclose(
+        rest1.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([3.0, 4.0, 5.0, 6.0]),
+    )
+    assert np.allclose(
+        rest1.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.0, 2.0, 3.0]),
+    )
+    assert np.allclose(
+        rest1.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([6.0, 6.0, 6.0, 6.0]),
     )
     window_list = create_window_list([rest1])
     assert window_list == [
@@ -100,27 +114,36 @@ def test_DAT_restraint():
     rest2.release["num_windows"] = rest2.attach["num_windows"]
     rest2.release["fc_final"] = rest2.attach["fc_final"]
     rest2.initialize()
+
+    target_units = unit.degrees
+    force_constant_units = unit.kcal / unit.mole / unit.radians ** 2
     assert rest2.index1 == [13, 31, 49, 67, 85, 103]
     assert rest2.index2 == [119]
     assert rest2.index3 == [109]
     assert rest2.index4 is None
     assert np.allclose(
-        rest2.phase["attach"]["force_constants"], np.array([0.0, 25.0, 50.0, 75.0])
+        rest2.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 25.0, 50.0, 75.0]),
     )
     assert np.allclose(
-        rest2.phase["attach"]["targets"], np.array([180.0, 180.0, 180.0, 180.0])
+        rest2.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([180.0, 180.0, 180.0, 180.0]),
     )
     assert np.allclose(
-        rest2.phase["pull"]["force_constants"], np.array([75.0, 75.0, 75.0, 75.0])
+        rest2.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([75.0, 75.0, 75.0, 75.0]),
     )
     assert np.allclose(
-        rest2.phase["pull"]["targets"], np.array([0.0, 60.0, 120.0, 180.0])
+        rest2.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 60.0, 120.0, 180.0]),
     )
     assert np.allclose(
-        rest2.phase["release"]["force_constants"], np.array([0.0, 25.0, 50.0, 75.0])
+        rest2.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 25.0, 50.0, 75.0]),
     )
     assert np.allclose(
-        rest2.phase["release"]["targets"], np.array([180.0, 180.0, 180.0, 180.0])
+        rest2.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([180.0, 180.0, 180.0, 180.0]),
     )
     window_list = create_window_list([rest2])
     assert window_list == [
@@ -159,27 +182,36 @@ def test_DAT_restraint():
     rest3.pull["target_final"] = 93.0
     rest3.release["fc_final"] = 75.0
     rest3.initialize()
+
+    target_units = unit.degrees
+    force_constant_units = unit.kcal / unit.mole / unit.radians ** 2
     assert rest3.index1 == [31]
     assert rest3.index2 == [13]
     assert rest3.index3 == [119]
     assert rest3.index4 == [109]
     assert np.allclose(
-        rest3.phase["attach"]["force_constants"], np.array([0.0, 25.0, 50.0, 75.0])
+        rest3.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 25.0, 50.0, 75.0]),
     )
     assert np.allclose(
-        rest3.phase["attach"]["targets"], np.array([90.0, 90.0, 90.0, 90.0])
+        rest3.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([90.0, 90.0, 90.0, 90.0]),
     )
     assert np.allclose(
-        rest3.phase["pull"]["force_constants"], np.array([75.0, 75.0, 75.0, 75.0])
+        rest3.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([75.0, 75.0, 75.0, 75.0]),
     )
     assert np.allclose(
-        rest3.phase["pull"]["targets"], np.array([90.0, 91.0, 92.0, 93.0])
+        rest3.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([90.0, 91.0, 92.0, 93.0]),
     )
     assert np.allclose(
-        rest3.phase["release"]["force_constants"], np.array([0.0, 25.0, 50.0, 75.0])
+        rest3.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 25.0, 50.0, 75.0]),
     )
     assert np.allclose(
-        rest3.phase["release"]["targets"], np.array([93.0, 93.0, 93.0, 93.0])
+        rest3.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([93.0, 93.0, 93.0, 93.0]),
     )
     window_list = create_window_list([rest3])
     assert window_list == [
@@ -220,23 +252,36 @@ def test_DAT_restraint():
     rest4.release["fc_increment"] = 25.0
     rest4.release["fc_final"] = 75.0
     rest4.initialize()
+
+    target_units = unit.degrees
+    force_constant_units = unit.kcal / unit.mole / unit.radians ** 2
     assert rest4.index1 == [31]
     assert rest4.index2 == [13]
     assert rest4.index3 == [119]
     assert rest4.index4 == [109]
     assert np.allclose(
-        rest4.phase["attach"]["force_constants"], np.array([0.0, 25.0, 50.0, 75.0])
-    )
-    assert np.allclose(rest4.phase["attach"]["targets"], np.array([0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(
-        rest4.phase["pull"]["force_constants"], np.array([75.0, 75.0, 75.0, 75.0])
-    )
-    assert np.allclose(rest4.phase["pull"]["targets"], np.array([0.0, 1.0, 2.0, 3.0]))
-    assert np.allclose(
-        rest4.phase["release"]["force_constants"], np.array([0.0, 25.0, 50.0, 75.0])
+        rest4.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 25.0, 50.0, 75.0]),
     )
     assert np.allclose(
-        rest4.phase["release"]["targets"], np.array([3.0, 3.0, 3.0, 3.0])
+        rest4.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.0, 0.0, 0.0]),
+    )
+    assert np.allclose(
+        rest4.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([75.0, 75.0, 75.0, 75.0]),
+    )
+    assert np.allclose(
+        rest4.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 1.0, 2.0, 3.0]),
+    )
+    assert np.allclose(
+        rest4.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 25.0, 50.0, 75.0]),
+    )
+    assert np.allclose(
+        rest4.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([3.0, 3.0, 3.0, 3.0]),
     )
     window_list = create_window_list([rest4])
     assert window_list == [
@@ -275,23 +320,36 @@ def test_DAT_restraint():
     rest5.release["fraction_list"] = [0.0, 0.3, 0.6, 1.0]
     rest5.release["fc_final"] = rest5.attach["fc_final"]
     rest5.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
     assert rest5.index1 == [13, 31, 49, 67, 85, 103]
     assert rest5.index2 == [109, 113, 115, 119]
     assert rest5.index3 is None
     assert rest5.index4 is None
     assert np.allclose(
-        rest5.phase["attach"]["force_constants"], np.array([0.0, 1.0, 2.5, 5.0])
-    )
-    assert np.allclose(rest5.phase["attach"]["targets"], np.array([0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(
-        rest5.phase["pull"]["force_constants"], np.array([5.0, 5.0, 5.0])
-    )
-    assert np.allclose(rest5.phase["pull"]["targets"], np.array([0.0, 0.5, 1.0]))
-    assert np.allclose(
-        rest5.phase["release"]["force_constants"], np.array([0.0, 1.5, 3.0, 5.0])
+        rest5.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.0, 2.5, 5.0]),
     )
     assert np.allclose(
-        rest5.phase["release"]["targets"], np.array([1.0, 1.0, 1.0, 1.0])
+        rest5.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.0, 0.0, 0.0]),
+    )
+    assert np.allclose(
+        rest5.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([5.0, 5.0, 5.0]),
+    )
+    assert np.allclose(
+        rest5.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.5, 1.0]),
+    )
+    assert np.allclose(
+        rest5.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.5, 3.0, 5.0]),
+    )
+    assert np.allclose(
+        rest5.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([1.0, 1.0, 1.0, 1.0]),
     )
     window_list = create_window_list([rest5])
     assert window_list == [
@@ -329,26 +387,37 @@ def test_DAT_restraint():
     rest6.release["fraction_increment"] = 0.33
     rest6.release["fc_final"] = rest6.attach["fc_final"]
     rest6.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
     assert rest6.index1 == [13, 31, 49, 67, 85, 103]
     assert rest6.index2 == [109, 113, 115, 119]
     assert rest6.index3 is None
     assert rest6.index4 is None
     assert np.allclose(
-        rest6.phase["attach"]["force_constants"], np.array([0.0, 1.25, 2.5, 3.75, 5.0])
+        rest6.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.25, 2.5, 3.75, 5.0]),
     )
     assert np.allclose(
-        rest6.phase["attach"]["targets"], np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        rest6.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
     )
     assert np.allclose(
-        rest6.phase["pull"]["force_constants"], np.array([5.0, 5.0, 5.0])
+        rest6.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([5.0, 5.0, 5.0]),
     )
-    assert np.allclose(rest6.phase["pull"]["targets"], np.array([0.0, 0.5, 1.0]))
+    assert np.allclose(
+        rest6.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.5, 1.0]),
+    )
     ### Note, the 6.6 in the following test is wrong ... needs to get fixed.
     assert np.allclose(
-        rest6.phase["release"]["force_constants"], np.array([0.0, 1.65, 3.3, 4.95, 6.6])
+        rest6.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.65, 3.3, 4.95, 6.6]),
     )
     assert np.allclose(
-        rest6.phase["release"]["targets"], np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        rest6.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([1.0, 1.0, 1.0, 1.0, 1.0]),
     )
     window_list = create_window_list([rest6])
     assert window_list == [
@@ -385,23 +454,36 @@ def test_DAT_restraint():
     rest7.release["target"] = 1.5
     rest7.release["fc_list"] = [0.0, 0.66, 1.2, 2.0]
     rest7.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
     assert rest7.index1 == [13, 14, 111]
     assert rest7.index2 == [3]
     assert rest7.index3 is None
     assert rest7.index4 is None
     assert np.allclose(
-        rest7.phase["attach"]["force_constants"], np.array([0.0, 0.5, 1.0, 2.0])
-    )
-    assert np.allclose(rest7.phase["attach"]["targets"], np.array([0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(
-        rest7.phase["pull"]["force_constants"], np.array([2.0, 2.0, 2.0, 2.0])
-    )
-    assert np.allclose(rest7.phase["pull"]["targets"], np.array([0.0, 0.5, 1.0, 1.5]))
-    assert np.allclose(
-        rest7.phase["release"]["force_constants"], np.array([0.0, 0.66, 1.2, 2.0])
+        rest7.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 0.5, 1.0, 2.0]),
     )
     assert np.allclose(
-        rest7.phase["release"]["targets"], np.array([1.5, 1.5, 1.5, 1.5])
+        rest7.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.0, 0.0, 0.0]),
+    )
+    assert np.allclose(
+        rest7.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([2.0, 2.0, 2.0, 2.0]),
+    )
+    assert np.allclose(
+        rest7.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.5, 1.0, 1.5]),
+    )
+    assert np.allclose(
+        rest7.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 0.66, 1.2, 2.0]),
+    )
+    assert np.allclose(
+        rest7.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([1.5, 1.5, 1.5, 1.5]),
     )
     window_list = create_window_list([rest7])
     assert window_list == [
@@ -433,14 +515,21 @@ def test_DAT_restraint():
     rest8.attach["fc_initial"] = 0.0
     rest8.attach["fc_final"] = 3.0
     rest8.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
     assert rest8.index1 == [13]
     assert rest8.index2 == [119]
     assert rest8.index3 is None
     assert rest8.index4 is None
     assert np.allclose(
-        rest8.phase["attach"]["force_constants"], np.array([0.0, 1.0, 2.0, 3.0])
+        rest8.phase["attach"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.0, 2.0, 3.0]),
     )
-    assert np.allclose(rest8.phase["attach"]["targets"], np.array([0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(
+        rest8.phase["attach"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.0, 0.0, 0.0]),
+    )
     assert rest8.phase["pull"]["force_constants"] is None
     assert rest8.phase["pull"]["targets"] is None
     assert rest8.phase["release"]["force_constants"] is None

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -553,6 +553,9 @@ def test_DAT_restraint():
     rest9.pull["target_initial"] = 0.0
     rest9.pull["target_final"] = 3.0
     rest9.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
     assert rest9.index1 == [13]
     assert rest9.index2 == [119]
     assert rest9.index3 is None
@@ -560,9 +563,13 @@ def test_DAT_restraint():
     assert rest9.phase["attach"]["force_constants"] is None
     assert rest9.phase["attach"]["targets"] is None
     assert np.allclose(
-        rest9.phase["pull"]["force_constants"], np.array([3.0, 3.0, 3.0, 3.0])
+        rest9.phase["pull"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([3.0, 3.0, 3.0, 3.0]),
     )
-    assert np.allclose(rest9.phase["pull"]["targets"], np.array([0.0, 1.0, 2.0, 3.0]))
+    assert np.allclose(
+        rest9.phase["pull"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 1.0, 2.0, 3.0]),
+    )
     assert rest9.phase["release"]["force_constants"] is None
     assert rest9.phase["release"]["targets"] is None
     window_list = create_window_list([rest9])
@@ -584,6 +591,9 @@ def test_DAT_restraint():
     rest10.release["fc_initial"] = 0.0
     rest10.release["fc_final"] = 2.0
     rest10.initialize()
+
+    target_units = unit.angstrom
+    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
     assert rest10.index1 == [13]
     assert rest10.index2 == [119]
     assert rest10.index3 is None
@@ -593,9 +603,13 @@ def test_DAT_restraint():
     assert rest10.phase["pull"]["force_constants"] is None
     assert rest10.phase["pull"]["targets"] is None
     assert np.allclose(
-        rest10.phase["release"]["force_constants"], np.array([0.0, 1.0, 2.0])
+        rest10.phase["release"]["force_constants"].to(force_constant_units).magnitude,
+        np.array([0.0, 1.0, 2.0]),
     )
-    assert np.allclose(rest10.phase["release"]["targets"], np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(
+        rest10.phase["release"]["targets"].to(target_units).magnitude,
+        np.array([0.0, 0.0, 0.0]),
+    )
     window_list = create_window_list([rest10])
     assert window_list == ["r000", "r001", "r002"]
 
@@ -633,20 +647,20 @@ def test_get_restraint_values():
     restraint.initialize()
 
     restraint_values = get_restraint_values(restraint, "attach", 0)
-    assert restraint_values["r1"] == 0.0
-    assert restraint_values["r2"] == 2.65
-    assert restraint_values["r3"] == 2.65
-    assert restraint_values["r4"] == 999.0
-    assert restraint_values["rk2"] == 0.0
-    assert restraint_values["rk3"] == 0.0
+    assert restraint_values["r1"].magnitude == 0.0
+    assert restraint_values["r2"].magnitude == 2.65
+    assert restraint_values["r3"].magnitude == 2.65
+    assert restraint_values["r4"].magnitude == 999.0
+    assert restraint_values["rk2"].magnitude == 0.0
+    assert restraint_values["rk3"].magnitude == 0.0
 
     restraint_values = get_restraint_values(restraint, "pull", 0)
-    assert restraint_values["r1"] == 0.0
-    assert restraint_values["r2"] == 2.65
-    assert restraint_values["r3"] == 2.65
-    assert restraint_values["r4"] == 999.0
-    assert restraint_values["rk2"] == 10.0
-    assert restraint_values["rk3"] == 10.0
+    assert restraint_values["r1"].magnitude == 0.0
+    assert restraint_values["r2"].magnitude == 2.65
+    assert restraint_values["r3"].magnitude == 2.65
+    assert restraint_values["r4"].magnitude == 999.0
+    assert restraint_values["rk2"].magnitude == 10.0
+    assert restraint_values["rk3"].magnitude == 10.0
 
     # Test custom values
     wall = DAT_restraint()
@@ -670,12 +684,12 @@ def test_get_restraint_values():
     wall.initialize()
 
     restraint_values = get_restraint_values(wall, "attach", 0)
-    assert restraint_values["r1"] == 0.0
-    assert restraint_values["r2"] == 0.0
-    assert restraint_values["r3"] == 3.5
-    assert restraint_values["r4"] == 999.0
-    assert restraint_values["rk2"] == 1.0
-    assert restraint_values["rk3"] == 1.0
+    assert restraint_values["r1"].magnitude == 0.0
+    assert restraint_values["r2"].magnitude == 0.0
+    assert restraint_values["r3"].magnitude == 3.5
+    assert restraint_values["r4"].magnitude == 999.0
+    assert restraint_values["rk2"].magnitude == 1.0
+    assert restraint_values["rk3"].magnitude == 1.0
 
     wall = DAT_restraint()
     wall.auto_apr = False
@@ -698,12 +712,12 @@ def test_get_restraint_values():
     wall.initialize()
 
     restraint_values = get_restraint_values(wall, "attach", 0)
-    assert restraint_values["r1"] == 0.0
-    assert restraint_values["r2"] == 3.5
-    assert restraint_values["r3"] == 0.0
-    assert restraint_values["r4"] == 999.0
-    assert restraint_values["rk2"] == 1.0
-    assert restraint_values["rk3"] == 1.0
+    assert restraint_values["r1"].magnitude == 0.0
+    assert restraint_values["r2"].magnitude == 3.5
+    assert restraint_values["r3"].magnitude == 0.0
+    assert restraint_values["r4"].magnitude == 999.0
+    assert restraint_values["rk2"].magnitude == 1.0
+    assert restraint_values["rk3"].magnitude == 1.0
 
 
 def test_get_bias_potential_type():

--- a/paprika/tests/test_simulate.py
+++ b/paprika/tests/test_simulate.py
@@ -3,6 +3,7 @@ import shutil
 
 import parmed as pmd
 import pytest
+from openff.units import unit
 
 from paprika import restraints
 from paprika.restraints import amber
@@ -82,8 +83,12 @@ def test_amber_single_window_gbmin(clean_files):
                 structure=True,
             )
             target_difference = (
-                restraint.phase["pull"]["targets"][int(window[1:])]
-                - restraint.phase["pull"]["targets"][0]
+                (
+                    restraint.phase["pull"]["targets"][int(window[1:])]
+                    - restraint.phase["pull"]["targets"][0]
+                )
+                .to(unit.angstrom)
+                .magnitude
             )
 
             for atom in structure.atoms:

--- a/paprika/tests/test_tleap.py
+++ b/paprika/tests/test_tleap.py
@@ -34,7 +34,7 @@ def clean_files(directory=os.path.join(os.path.dirname(__file__), "tmp")):
 
 @pytest.mark.slow
 def test_solvation_simple(clean_files):
-    """ Test that we can solvate CB6-BUT using default settings. """
+    """Test that we can solvate CB6-BUT using default settings."""
     waters = np.random.randint(100, 10000)
     logger.debug("Trying {} waters with default settings...".format(waters))
     sys = TLeap()
@@ -53,7 +53,7 @@ def test_solvation_simple(clean_files):
 
 @pytest.mark.parametrize("shape", [PBCBox.octahedral, PBCBox.cubic])
 def test_solvation_shapes(shape, clean_files):
-    """ Test that we can solvate CB6-BUT with a truncated octahedron. """
+    """Test that we can solvate CB6-BUT with a truncated octahedron."""
     waters = np.random.randint(1000, 10000)
     logger.debug("Trying {} waters in a truncated octahedron...".format(waters))
     sys = TLeap()
@@ -76,7 +76,7 @@ def test_solvation_shapes(shape, clean_files):
 
 @pytest.mark.parametrize("water_model", ["tip4p", "opc"])
 def test_solvation_water_model(water_model, clean_files):
-    """ Test that we can solvate CB6-BUT with a truncated octahedron. """
+    """Test that we can solvate CB6-BUT with a truncated octahedron."""
     waters = np.random.randint(1000, 10000)
     logger.debug("Trying {} waters in a truncated octahedron...".format(waters))
     sys = TLeap()
@@ -150,7 +150,7 @@ def test_solvation_bind3p(clean_files):
 
 @pytest.mark.slow
 def test_solvation_spatial_size(clean_files):
-    """ Test that we can solvate CB6-BUT with an buffer size in Angstroms. """
+    """Test that we can solvate CB6-BUT with an buffer size in Angstroms."""
     random_int = np.random.randint(10, 20)
     random_size = random_int * np.random.random_sample(1) + random_int
     logger.debug("Trying buffer size of {} A...".format(random_size[0]))
@@ -174,7 +174,7 @@ def test_solvation_spatial_size(clean_files):
 
 @pytest.mark.slow
 def test_solvation_potassium_control(clean_files):
-    """ Test there is no potassium by default. A negative control. """
+    """Test there is no potassium by default. A negative control."""
     waters = np.random.randint(1000, 10000)
     logger.debug("Trying {} waters with potassium...".format(waters))
     sys = TLeap()
@@ -197,7 +197,7 @@ def test_solvation_potassium_control(clean_files):
 
 @pytest.mark.slow
 def test_solvation_with_additional_ions(clean_files):
-    """ Test that we can solvate CB6-BUT with additional ions. """
+    """Test that we can solvate CB6-BUT with additional ions."""
     waters = np.random.randint(1000, 10000)
     cations = ["LI", "Na+", "K+", "RB", "CS"]
     anions = ["F", "Cl-", "BR", "IOD"]
@@ -245,7 +245,7 @@ def test_solvation_with_additional_ions(clean_files):
 
 
 def test_solvation_by_M_and_m(clean_files):
-    """ Test that we can solvate CB6-BUT through molarity and molality. """
+    """Test that we can solvate CB6-BUT through molarity and molality."""
     logger.debug("Trying 10 A buffer with 150 mM NaCl...")
     sys = TLeap()
     sys.template_file = os.path.join(
@@ -297,7 +297,7 @@ def test_solvation_by_M_and_m(clean_files):
 
 @pytest.mark.slow
 def test_alignment_workflow(clean_files):
-    """ Test that we can solvate CB6-BUT after alignment. """
+    """Test that we can solvate CB6-BUT after alignment."""
     cb6 = pmd.load_file(
         os.path.join(
             os.path.dirname(__file__), "../data/cb6-but/cb6-but-notcentered.pdb"
@@ -322,7 +322,7 @@ def test_alignment_workflow(clean_files):
 
 
 def test_hydrogen_mass_repartitioning(clean_files):
-    """ Test that hydrogen mass is repartitioned. """
+    """Test that hydrogen mass is repartitioned."""
     temporary_directory = os.path.join(os.path.dirname(__file__), "tmp")
     sys = TLeap()
     but_frcmod = os.path.abspath(
@@ -402,7 +402,7 @@ def test_multiple_pdb_files(clean_files):
 
 
 def test_conversions(clean_files):
-    """ Test that conversion methods work in Tleap module. """
+    """Test that conversion methods work in Tleap module."""
     temporary_directory = os.path.join(os.path.dirname(__file__), "tmp")
 
     but_frcmod = os.path.abspath(
@@ -476,7 +476,7 @@ def test_conversions(clean_files):
 
 
 def test_ion_solvation(clean_files):
-    """ Test that tleap module is solvating an ion properly."""
+    """Test that tleap module is solvating an ion properly."""
     temporary_directory = os.path.join(os.path.dirname(__file__), "tmp")
 
     ions = ["Na+", "Cl-"]

--- a/paprika/tests/test_utils.py
+++ b/paprika/tests/test_utils.py
@@ -22,7 +22,7 @@ def clean_files(directory=os.path.join(os.path.dirname(__file__), "tmp")):
 
 
 def test_mkdirs():
-    """ Test that we can make directories for the windows. """
+    """Test that we can make directories for the windows."""
     window_list = ["a000", "p014", "r089"]
     make_window_dirs(window_list, path="tmp")
     for window in window_list:
@@ -30,7 +30,7 @@ def test_mkdirs():
 
 
 def test_strip_prmtop():
-    """ Test that we can remove items from structures. """
+    """Test that we can remove items from structures."""
     cb6_only = strip_prmtop(
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.prmtop"),
         mask=":BUT",

--- a/paprika/utils.py
+++ b/paprika/utils.py
@@ -4,6 +4,7 @@ import shutil
 from datetime import datetime
 from functools import lru_cache
 
+import numpy as np
 import parmed as pmd
 import pytraj as pt
 from openff.units import unit
@@ -342,6 +343,8 @@ def check_unit(variable, base_unit):
             raise KeyError(
                 "Please make my life easier by either specifying a list of all float or all unit.Quantity."
             )
+    elif isinstance(variable, np.ndarray):
+        quantity = unit.Quantity(variable, units=base_unit)
     else:
         raise KeyError("``variable`` should be a float or unit.Quantity.")
 


### PR DESCRIPTION
PR to implement https://github.com/slochower/pAPRika/issues/135 through the `openff-units` wrapper. Most of the changes are in the `restraints` and `analysis` modules. Users can still specify equilibrium targets and force constants values as floats but will be converted into a `unit.Quantity` object (defaults to AMBER units). The `save_restraints` function will add units for `unit.Quantity` variables and `load_restraints` will load the variable back with the proper units.