### PR TITLE
Update import namespace for OpenMM and add unit tests for restraints modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.8, 3.9]
     env:
       PYVER: ${{ matrix.python-version }}
       PACKAGE: paprika

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install the package
         run: |
           python setup.py develop --no-deps
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run isort
         run: |
-          isort --check-only paprika
+          isort --profile=black --check-only paprika
 
       - name: Run black
         run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: paprika-dev
 channels:
   - conda-forge
-  - omnia
 dependencies:
   
   # Base depends
@@ -12,7 +11,7 @@ dependencies:
   - parmed
   - mdtraj
   - pymbar >=3.0.5
-  - openmm >=7.5.0
+  - openmm >=7.6.0
   - yank
   - ambertools >=20.0
   - pyyaml
@@ -27,8 +26,12 @@ dependencies:
   - flake8
   
   # Documentation
+  - numpydoc
+  - pandoc
   - sphinx
+  - nbsphinx
   - sphinx_rtd_theme
+  - sphinxcontrib-bibtex ==1.0.0
 
   # Testing
   - pytest

--- a/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
+++ b/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
@@ -603,9 +603,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import simtk.unit as unit\n",
-    "import simtk.openmm.app as app\n",
-    "import simtk.openmm as openmm\n",
+    "import openmm.unit as unit\n",
+    "import openmm.app as app\n",
+    "import openmm as openmm\n",
     "\n",
     "from paprika.restraints.utils import parse_window\n",
     "from paprika.restraints.openmm import apply_positional_restraints, apply_dat_restraint"

--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy as np
 import parmed as pmd
-from openff.units import unit
+from openff.units import unit as pint_unit
 from paprika.utils import check_unit
 
 logger = logging.getLogger(__name__)
@@ -169,7 +169,7 @@ def rotate_around_axis(structure, axis, angle):
         Molecular structure containing coordinates.
     axis: str or list or :class:`numpy.ndarray`
         The axis of rotation. If an array is specified, the axis-vector will be normalized automatically.
-    angle: float or unit.Quantity
+    angle: float or pint.unit.Quantity
         The angle of rotation in degrees.
 
     Returns
@@ -190,7 +190,7 @@ def rotate_around_axis(structure, axis, angle):
     axis = _return_array(axis)
 
     # Convert angle to radians (temporary until Pint integration)
-    angle = check_unit(angle, base_unit=unit.radians).to(unit.radians).magnitude
+    angle = check_unit(angle, base_unit=pint_unit.radians).to(pint_unit.radians).magnitude
 
     if np.array_equal(axis, np.array([1.0, 0.0, 0.0])):
         rotation_matrix = np.array(
@@ -300,7 +300,7 @@ def get_theta(structure, mask1, mask2, axis):
         np.dot(vector, axis) / (np.linalg.norm(vector) * np.linalg.norm(axis))
     )
 
-    return unit.Quantity(theta, units=unit.radians)
+    return pint_unit.Quantity(theta, units=pint_unit.radians)
 
 
 def get_rotation_matrix(vector, ref_vector):
@@ -431,7 +431,7 @@ def offset_structure(structure, offset, dimension=None):
     ----------
     structure : :class:`parmed.Structure`
         Molecular structure containing coordinates.
-    offset : float or :class:`numpy.ndarray` or unit.Quantity
+    offset : float or :class:`numpy.ndarray` or pint.unit.Quantity
         The offset that will be added to *every* atom in the structure.
     dimension : str or list or :class:`numpy.ndarray`, optional, default=None
         By default the structure will be moved by ``offset`` in all direction if it is a single number, i.e. ``xyz +
@@ -461,9 +461,9 @@ def offset_structure(structure, offset, dimension=None):
     else:
         mask = _return_array(dimension)
 
-    offset = check_unit(offset, base_unit=unit.angstrom)
+    offset = check_unit(offset, base_unit=pint_unit.angstrom)
     offset *= mask
-    offset = offset.to(unit.angstrom).magnitude
+    offset = offset.to(pint_unit.angstrom).magnitude
 
     # Offset coordinates
     offset_coords = np.empty_like(structure.coordinates)

--- a/paprika/build/dummy.py
+++ b/paprika/build/dummy.py
@@ -5,18 +5,18 @@ from parmed.structure import Structure as ParmedStructureClass
 
 from paprika import utils
 from paprika.utils import check_unit
-from openff.units import unit
+from openff.units import unit as pint_unit
 
 
 def add_dummy(
     structure,
     atom_name="DUM",
     residue_name="DUM",
-    mass=208.00 * unit.dalton,
+    mass=208.00 * pint_unit.dalton,
     atomic_number=82,
-    x=0.000 * unit.angstrom,
-    y=0.000 * unit.angstrom,
-    z=0.000 * unit.angstrom,
+    x=0.000 * pint_unit.angstrom,
+    y=0.000 * pint_unit.angstrom,
+    z=0.000 * pint_unit.angstrom,
 ):
     """Add a dummy atom at the specified coordinates to the end of a structure.
 
@@ -46,10 +46,10 @@ def add_dummy(
 
     """
 
-    mass = check_unit(mass, base_unit=unit.dalton)
-    x = check_unit(x, base_unit=unit.angstrom)
-    y = check_unit(y, base_unit=unit.angstrom)
-    z = check_unit(z, base_unit=unit.angstrom)
+    mass = check_unit(mass, base_unit=pint_unit.dalton)
+    x = check_unit(x, base_unit=pint_unit.angstrom)
+    y = check_unit(y, base_unit=pint_unit.angstrom)
+    z = check_unit(z, base_unit=pint_unit.angstrom)
 
     if isinstance(structure, str):
         structure = utils.return_parmed_structure(structure)
@@ -64,14 +64,14 @@ def add_dummy(
     # Create an atom object
     dum = pmd.topologyobjects.Atom()
     dum.name = atom_name
-    dum.mass = mass.to(unit.dalton).magnitude
+    dum.mass = mass.to(pint_unit.dalton).magnitude
     dum.atomic_number = atomic_number
     # This may be a problem if these coordinates are outside the periodic box
     # dimensions and ParmEd does not recalculate the box vectors before saving
     # `inpcrd`...
-    dum.xx = x.to(unit.angstrom).magnitude
-    dum.xy = y.to(unit.angstrom).magnitude
-    dum.xz = z.to(unit.angstrom).magnitude
+    dum.xx = x.to(pint_unit.angstrom).magnitude
+    dum.xy = y.to(pint_unit.angstrom).magnitude
+    dum.xz = z.to(pint_unit.angstrom).magnitude
 
     # Assume that the last atom in the structure has the highest atom index,
     # so the new atom will be at the end.

--- a/paprika/restraints/amber.py
+++ b/paprika/restraints/amber.py
@@ -1,6 +1,6 @@
 import logging
 
-from openff.units import unit
+from openff.units import unit as pint_unit
 
 from paprika.restraints.utils import get_restraint_values, parse_window
 
@@ -83,13 +83,15 @@ def amber_restraint_line(restraint, window):
     amber_restraint_values = get_restraint_values(restraint, phase, window)
 
     # Amber units
-    energy_unit = unit.kcal / unit.mole
+    energy_unit = pint_unit.kcal / pint_unit.mole
     target_unit = (
-        unit.angstrom if restraint.restraint_type == "distance" else unit.degrees
+        pint_unit.angstrom
+        if restraint.restraint_type == "distance"
+        else pint_unit.degrees
     )
     force_constant_unit = energy_unit / target_unit ** 2
     if not restraint.restraint_type == "distance":
-        force_constant_unit = energy_unit / unit.radians ** 2
+        force_constant_unit = energy_unit / pint_unit.radians ** 2
 
     # Prepare AMBER NMR-style restraint
     atoms = "".join([iat1, iat2, iat3, iat4])

--- a/paprika/restraints/colvars.py
+++ b/paprika/restraints/colvars.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import numpy as np
-from openff.units import unit
+from openff.units import unit as pint_unit
 
 from paprika.restraints.plumed import Plumed
 from paprika.restraints.utils import get_bias_potential_type, parse_window
@@ -149,18 +149,20 @@ class Colvars(Plumed):
                 atom_string = " ".join(map(str, atom_index))
 
                 # Convert units to the correct type for COLVAR module
-                energy_units = unit.kcal / unit.mole
+                energy_units = pint_unit.kcal / pint_unit.mole
                 if restraint.restraint_type == "distance":
-                    target = target.to(unit.angstrom)
+                    target = target.to(pint_unit.angstrom)
                     force_constant = force_constant.to(
-                        energy_units / unit.angstrom ** 2
+                        energy_units / pint_unit.angstrom ** 2
                     )
                 elif (
                     restraint.restraint_type == "angle"
                     or restraint.restraint_type == "torsion"
                 ):
-                    target = target.to(unit.degrees)
-                    force_constant = force_constant.to(energy_units / unit.degrees ** 2)
+                    target = target.to(pint_unit.degrees)
+                    force_constant = force_constant.to(
+                        energy_units / pint_unit.degrees ** 2
+                    )
 
                 # Determine bias type for this restraint
                 bias_type = get_bias_potential_type(restraint, phase, window_number)
@@ -316,7 +318,7 @@ class Colvars(Plumed):
             The file object handle to save the plumed file.
         dummy_atoms : dict
             Dictionary containing information about the dummy atoms.
-        kpos : float or unit.Quantity
+        kpos : float or pint_unit.Quantity
             Spring constant used to restrain dummy atoms (default for float: kcal/mol/A^2).
 
         Examples
@@ -336,7 +338,9 @@ class Colvars(Plumed):
             }
         """
         # Check k units
-        kpos = check_unit(kpos, base_unit=unit.kcal / unit.mole / unit.angstrom ** 2)
+        kpos = check_unit(
+            kpos, base_unit=pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+        )
 
         # Get dummy atom indices
         dummy_indices = [dummy_atoms[key]["idx"] for key in dummy_atoms.keys()]

--- a/paprika/restraints/plumed.py
+++ b/paprika/restraints/plumed.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import numpy as np
-from openff.units import unit
+from openff.units import unit as pint_unit
 from parmed.structure import Structure as ParmedStructureClass
 
 from paprika.build.dummy import extract_dummy_atoms
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 _PI_ = np.pi
 
 _plumed_unit_dict = {
-    unit.kcal / unit.mole: "kcal/mol",
-    unit.kJ / unit.mole: "kj/mol",
-    unit.nanometer: "nm",
-    unit.angstrom: "A",
-    unit.picosecond: "ps",
-    unit.femtosecond: "fs",
-    unit.nanosecond: "ns",
+    pint_unit.kcal / pint_unit.mole: "kcal/mol",
+    pint_unit.kJ / pint_unit.mole: "kj/mol",
+    pint_unit.nanometer: "nm",
+    pint_unit.angstrom: "A",
+    pint_unit.picosecond: "ps",
+    pint_unit.femtosecond: "fs",
+    pint_unit.nanosecond: "ns",
 }
 
 
@@ -208,9 +208,9 @@ class Plumed:
         # Check user-specified units
         if self.output_units is None:
             self.output_units = {
-                "energy": unit.kcal / unit.mole,
-                "length": unit.angstrom,
-                "time": unit.nanosecond,
+                "energy": pint_unit.kcal / pint_unit.mole,
+                "length": pint_unit.angstrom,
+                "time": pint_unit.nanosecond,
             }
         _check_plumed_units(self.output_units)
 
@@ -264,7 +264,7 @@ class Plumed:
 
                 # Convert units to the correct type for PLUMED module
                 if restraint.restraint_type == "distance":
-                    target = target.to(unit.angstrom)
+                    target = target.to(pint_unit.angstrom)
                     force_constant = force_constant.to(
                         self.output_units["energy"] / self.output_units["length"] ** 2
                     )
@@ -272,9 +272,9 @@ class Plumed:
                     restraint.restraint_type == "angle"
                     or restraint.restraint_type == "torsion"
                 ):
-                    target = target.to(unit.radians)
+                    target = target.to(pint_unit.radians)
                     force_constant = force_constant.to(
-                        self.output_units["energy"] / unit.radians ** 2
+                        self.output_units["energy"] / pint_unit.radians ** 2
                     )
 
                 # Determine bias type for this restraint

--- a/paprika/restraints/restraints.py
+++ b/paprika/restraints/restraints.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import parmed as pmd
 import pytraj as pt
-from openff.units import unit
+from openff.units import unit as pint_unit
 
 from paprika import utils
 from paprika.utils import check_unit
@@ -577,12 +577,12 @@ class DAT_restraint(object):
         """
 
         # Set default units (Based on Amber)
-        energy_unit = unit.kcal / unit.mole
-        target_unit = unit.angstrom
-        force_constant_unit = energy_unit / unit.angstrom ** 2
+        energy_unit = pint_unit.kcal / pint_unit.mole
+        target_unit = pint_unit.angstrom
+        force_constant_unit = energy_unit / pint_unit.angstrom ** 2
         if self.mask3 or self.mask4:
-            target_unit = unit.degrees
-            force_constant_unit = energy_unit / unit.radians ** 2
+            target_unit = pint_unit.degrees
+            force_constant_unit = energy_unit / pint_unit.radians ** 2
 
         # Check attach/release units
         for phase in [self._attach, self._release]:
@@ -898,7 +898,7 @@ def static_DAT_restraint(
         pull windows, release windows].
     ref_structure: os.PathLike or :class:`parmed.Structure`
         The reference structure that is used to determine the initial, **static** value for this restraint.
-    force_constant: float or unit.Quantity
+    force_constant: float or pint.unit.Quantity
         The force constant for this restraint. If float, the number will be transformed to kcal/mol/[Angstrom,radians].
     continuous_apr: bool, optional
         Whether this restraint uses ``continuous_apr``. This must be consistent with existing restraints.
@@ -943,13 +943,13 @@ def static_DAT_restraint(
     if len(restraint_mask_list) == 4:
         rest.mask4 = restraint_mask_list[3]
 
-    # Force constant - convert to unit.Quantity
+    # Force constant - convert to pint.unit.Quantity
     force_constant = check_unit(
         force_constant,
         base_unit=(
-            unit.kcal / unit.mole / unit.angstrom ** 2
+            pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
             if len(restraint_mask_list) == 2
-            else unit.kcal / unit.mole / unit.radians ** 2
+            else pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
         ),
     )
 
@@ -963,17 +963,17 @@ def static_DAT_restraint(
         else:
             target = pt.distance(reference_trajectory, mask_string, image=False)[0]
             logger.debug("Calculating distance with 'image = False' ...")
-        target = unit.Quantity(target, units=unit.angstrom)
+        target = pint_unit.Quantity(target, units=pint_unit.angstrom)
 
     elif len(restraint_mask_list) == 3:
         # Angle restraint
         target = pt.angle(reference_trajectory, mask_string)[0]
-        target = unit.Quantity(target, units=unit.degrees)
+        target = pint_unit.Quantity(target, units=pint_unit.degrees)
 
     elif len(restraint_mask_list) == 4:
         # Dihedral restraint
         target = pt.dihedral(reference_trajectory, mask_string)[0]
-        target = unit.Quantity(target, units=unit.degrees)
+        target = pint_unit.Quantity(target, units=pint_unit.degrees)
 
     else:
         raise IndexError(

--- a/paprika/restraints/utils.py
+++ b/paprika/restraints/utils.py
@@ -1,7 +1,7 @@
 import logging
 
 import numpy as np
-from openff.units import unit
+from openff.units import unit as pint_unit
 
 from paprika.utils import override_dict
 
@@ -63,19 +63,19 @@ def get_restraint_values(restraint, phase, window_number):
     """
 
     # Amber NMR bounds
-    lower_bound = 0.0 * unit.angstrom
-    upper_bound = 999.0 * unit.angstrom
+    lower_bound = 0.0 * pint_unit.angstrom
+    upper_bound = 999.0 * pint_unit.angstrom
 
     if restraint.mask3 and not restraint.mask4:
-        lower_bound = 0.0 * unit.degrees
-        upper_bound = 180.0 * unit.degrees
+        lower_bound = 0.0 * pint_unit.degrees
+        upper_bound = 180.0 * pint_unit.degrees
 
     if restraint.mask3 and restraint.mask4:
         lower_bound = (
-            restraint.phase[phase]["targets"][window_number] - 180.0 * unit.degrees
+            restraint.phase[phase]["targets"][window_number] - 180.0 * pint_unit.degrees
         )
         upper_bound = (
-            restraint.phase[phase]["targets"][window_number] + 180.0 * unit.degrees
+            restraint.phase[phase]["targets"][window_number] + 180.0 * pint_unit.degrees
         )
 
     restraint_values = {

--- a/paprika/simulate/namd.py
+++ b/paprika/simulate/namd.py
@@ -598,17 +598,17 @@ class NAMD(Simulation, abc.ABC):
 
         # Check if box info exists
         if structure.box_vectors:
-            import simtk.unit as unit
+            import openmm.unit as openmm_unit
 
             self.cell_basis_vectors["cellBasisVector1"] = structure.box_vectors[
                 0
-            ].value_in_unit(unit.angstroms)
+            ].value_in_unit(openmm_unit.angstroms)
             self.cell_basis_vectors["cellBasisVector2"] = structure.box_vectors[
                 1
-            ].value_in_unit(unit.angstroms)
+            ].value_in_unit(openmm_unit.angstroms)
             self.cell_basis_vectors["cellBasisVector3"] = structure.box_vectors[
                 2
-            ].value_in_unit(unit.angstroms)
+            ].value_in_unit(openmm_unit.angstroms)
 
         else:
             self.cell_basis_vectors["cellBasisVector1"] = [

--- a/paprika/tests/addons.py
+++ b/paprika/tests/addons.py
@@ -29,7 +29,7 @@ _import_message = (
 _exe_message = "Cannot detect executable {}. Install package if necessary."
 
 using_openmm = pytest.mark.skipif(
-    _plugin_import("simtk.openmm") is False, reason=_import_message.format("OpenMM")
+    _plugin_import("openmm") is False, reason=_import_message.format("OpenMM")
 )
 using_sander = pytest.mark.skipif(
     _find_executable("sander") is False, reason=_import_message.format("sander")

--- a/paprika/tests/test_evaluator.py
+++ b/paprika/tests/test_evaluator.py
@@ -231,22 +231,10 @@ def test_evaluator_gaff(clean_files):
         os.path.join(temporary_directory, f"but.{gaff_version}.mol2")
     )
 
-    butane_atom_type = [
-        "c3",
-        "hc",
-        "hc",
-        "hc",
-        "c3",
-        "hc",
-        "c3",
-        "hc",
-        "hc",
-        "hc",
-        "c3",
-        "hc",
-        "hc",
-        "hc",
-    ]
+    # fmt: off
+    butane_atom_type = ["c3", "hc", "hc", "hc", "c3", "hc", "c3", "hc", "hc", "hc", "c3", "hc", "hc", "hc"]
+    # fmt: on
+
     residue_names = []
     for i, atom in enumerate(structure.topology.atoms):
         if atom.resname not in residue_names:

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -1,21 +1,25 @@
 """
 Tests the restraints utilities.
 """
-
 import logging
 import os
 
 import numpy as np
+import openmm
+import openmm.app as app
+import openmm.unit as openmm_unit
 import parmed as pmd
 import pytest
-from openff.units import unit
+from openff.units import unit as pint_unit
 
+from paprika.restraints.openmm import apply_dat_restraint, apply_positional_restraints
 from paprika.restraints.restraints import DAT_restraint, create_window_list
 from paprika.restraints.utils import (
     extract_guest_restraints,
     get_bias_potential_type,
     get_restraint_values,
 )
+from paprika.tests.test_tleap import clean_files
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +50,8 @@ def test_DAT_restraint():
     rest1.release["fc_final"] = rest1.attach["fc_final"]
     rest1.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / target_units ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / target_units ** 2
     assert rest1.index1 == [13, 31, 49, 67, 85, 103]
     assert rest1.index2 == [119]
     assert rest1.index3 is None
@@ -115,8 +119,8 @@ def test_DAT_restraint():
     rest2.release["fc_final"] = rest2.attach["fc_final"]
     rest2.initialize()
 
-    target_units = unit.degrees
-    force_constant_units = unit.kcal / unit.mole / unit.radians ** 2
+    target_units = pint_unit.degrees
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
     assert rest2.index1 == [13, 31, 49, 67, 85, 103]
     assert rest2.index2 == [119]
     assert rest2.index3 == [109]
@@ -183,8 +187,8 @@ def test_DAT_restraint():
     rest3.release["fc_final"] = 75.0
     rest3.initialize()
 
-    target_units = unit.degrees
-    force_constant_units = unit.kcal / unit.mole / unit.radians ** 2
+    target_units = pint_unit.degrees
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
     assert rest3.index1 == [31]
     assert rest3.index2 == [13]
     assert rest3.index3 == [119]
@@ -253,8 +257,8 @@ def test_DAT_restraint():
     rest4.release["fc_final"] = 75.0
     rest4.initialize()
 
-    target_units = unit.degrees
-    force_constant_units = unit.kcal / unit.mole / unit.radians ** 2
+    target_units = pint_unit.degrees
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
     assert rest4.index1 == [31]
     assert rest4.index2 == [13]
     assert rest4.index3 == [119]
@@ -321,8 +325,8 @@ def test_DAT_restraint():
     rest5.release["fc_final"] = rest5.attach["fc_final"]
     rest5.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
     assert rest5.index1 == [13, 31, 49, 67, 85, 103]
     assert rest5.index2 == [109, 113, 115, 119]
     assert rest5.index3 is None
@@ -388,8 +392,8 @@ def test_DAT_restraint():
     rest6.release["fc_final"] = rest6.attach["fc_final"]
     rest6.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
     assert rest6.index1 == [13, 31, 49, 67, 85, 103]
     assert rest6.index2 == [109, 113, 115, 119]
     assert rest6.index3 is None
@@ -455,8 +459,8 @@ def test_DAT_restraint():
     rest7.release["fc_list"] = [0.0, 0.66, 1.2, 2.0]
     rest7.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
     assert rest7.index1 == [13, 14, 111]
     assert rest7.index2 == [3]
     assert rest7.index3 is None
@@ -516,8 +520,8 @@ def test_DAT_restraint():
     rest8.attach["fc_final"] = 3.0
     rest8.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
     assert rest8.index1 == [13]
     assert rest8.index2 == [119]
     assert rest8.index3 is None
@@ -554,8 +558,8 @@ def test_DAT_restraint():
     rest9.pull["target_final"] = 3.0
     rest9.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
     assert rest9.index1 == [13]
     assert rest9.index2 == [119]
     assert rest9.index3 is None
@@ -592,8 +596,8 @@ def test_DAT_restraint():
     rest10.release["fc_final"] = 2.0
     rest10.initialize()
 
-    target_units = unit.angstrom
-    force_constant_units = unit.kcal / unit.mole / unit.angstrom ** 2
+    target_units = pint_unit.angstrom
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
     assert rest10.index1 == [13]
     assert rest10.index2 == [119]
     assert rest10.index3 is None
@@ -1093,3 +1097,285 @@ def test_extract_guest_restraints():
     assert guest_restraints[3] is not None
     assert guest_restraints[4] is not None
     assert guest_restraints[5] is not None
+
+
+def test_restraints_output_modules(clean_files):
+    """Test restraints output modules (colvars, plumed, openmm, amber)."""
+    import paprika.build.dummy as dummy
+    from paprika.restraints.amber import amber_restraint_line
+    from paprika.restraints.colvars import Colvars
+    from paprika.restraints.plumed import Plumed
+    from paprika.restraints.utils import parse_window
+
+    window = "p000"
+    window_number, phase = parse_window(window)
+    os.makedirs(os.path.join("tmp", window))
+
+    # Test OpenMM restraint modules
+    prmtop_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.prmtop")
+    )
+    inpcrd_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../data/cb6-but/vac.rst7")
+    )
+
+    # Add Dummy atoms
+    structure = pmd.load_file(prmtop_path, inpcrd_path, structure=True)
+
+    dummy_atoms = {
+        0: {"resname": "DM1", "x": 0.0, "y": 0.0, "z": -6.0},
+        1: {"resname": "DM2", "x": 0.0, "y": 0.0, "z": -9.0},
+        2: {"resname": "DM3", "x": 0.0, "y": 2.2, "z": -11.2},
+    }
+    for i in dummy_atoms:
+        structure = dummy.add_dummy(
+            structure,
+            residue_name=dummy_atoms[i]["resname"],
+            x=dummy_atoms[i]["x"],
+            y=dummy_atoms[i]["y"],
+            z=dummy_atoms[i]["z"],
+        )
+
+    # Create DAT restraints
+    guest_restraints = []
+
+    # Guest - r
+    r = DAT_restraint()
+    r.amber_index = True
+    r.continuous_apr = True
+    r.auto_apr = True
+    r.topology = os.path.join(
+        os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"
+    )
+    r.mask1 = ":DM1"
+    r.mask2 = ":BUT@C3"
+    r.attach["target"] = 6.0
+    r.attach["num_windows"] = 4
+    r.attach["fc_initial"] = 0.0
+    r.attach["fc_final"] = 5.0
+    r.pull["fc"] = r.attach["fc_final"]
+    r.pull["num_windows"] = 46
+    r.pull["target_initial"] = r.attach["target"]
+    r.pull["target_final"] = 24.0
+    r.release["target"] = r.pull["target_final"]
+    r.release["num_windows"] = r.attach["num_windows"]
+    r.release["fc_initial"] = r.attach["fc_initial"]
+    r.release["fc_final"] = r.attach["fc_final"]
+    r.initialize()
+    guest_restraints.append(r)
+
+    # Guest - theta
+    r = DAT_restraint()
+    r.amber_index = True
+    r.continuous_apr = True
+    r.auto_apr = True
+    r.topology = os.path.join(
+        os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"
+    )
+    r.mask1 = ":DM1"
+    r.mask2 = ":BUT@C3"
+    r.mask3 = ":BUT@C"
+    r.attach["target"] = 180.0
+    r.attach["num_windows"] = 15
+    r.attach["fc_initial"] = 0.0
+    r.attach["fc_final"] = 100.0
+    r.pull["fc"] = r.attach["fc_final"]
+    r.pull["num_windows"] = 46
+    r.pull["target_initial"] = r.attach["target"]
+    r.pull["target_final"] = 180.0
+    r.release["target"] = r.pull["target_final"]
+    r.release["num_windows"] = r.attach["num_windows"]
+    r.release["fc_initial"] = r.attach["fc_initial"]
+    r.release["fc_final"] = r.attach["fc_final"]
+    r.initialize()
+    guest_restraints.append(r)
+
+    # Guest - beta
+    r = DAT_restraint()
+    r.amber_index = True
+    r.continuous_apr = True
+    r.auto_apr = True
+    r.topology = os.path.join(
+        os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"
+    )
+    r.mask1 = ":DM2"
+    r.mask2 = ":DM1"
+    r.mask3 = ":BUT@C3"
+    r.attach["target"] = 180.0
+    r.attach["num_windows"] = 15
+    r.attach["fc_initial"] = 0.0
+    r.attach["fc_final"] = 100.0
+    r.pull["fc"] = r.attach["fc_final"]
+    r.pull["num_windows"] = 46
+    r.pull["target_initial"] = r.attach["target"]
+    r.pull["target_final"] = 180.0
+    r.release["target"] = r.pull["target_final"]
+    r.release["num_windows"] = r.attach["num_windows"]
+    r.release["fc_initial"] = r.attach["fc_initial"]
+    r.release["fc_final"] = r.attach["fc_final"]
+    r.initialize()
+    guest_restraints.append(r)
+
+    # Create OpenMM System
+    system = structure.createSystem(
+        nonbondedMethod=app.NoCutoff,
+        constraints=app.HBonds,
+    )
+
+    # Create restraints for OpenMM system
+    kpos = 50.0 * openmm_unit.kilocalories_per_mole / openmm_unit.angstrom ** 2
+    apply_positional_restraints(
+        os.path.join(os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"),
+        system,
+        kpos=kpos,
+    )
+    for restraint in guest_restraints:
+        apply_dat_restraint(system, restraint, phase=phase, window_number=window_number)
+
+    positional_restraints = [
+        force
+        for force in system.getForces()
+        if isinstance(force, openmm.CustomExternalForce)
+    ]
+    DAT_restraint_list = [
+        force
+        for force in system.getForces()
+        if isinstance(force, openmm.CustomBondForce)
+        or isinstance(force, openmm.CustomAngleForce)
+        or isinstance(force, openmm.CustomTorsionForce)
+    ]
+
+    # Test dummy atom positional restraint
+    for i, force in enumerate(positional_restraints):
+        particle, parameters = force.getParticleParameters(0)
+        assert pytest.approx(parameters[0], abs=1e-3) == kpos.value_in_unit(
+            openmm_unit.kilojoule_per_mole / openmm_unit.nanometer ** 2
+        )
+        assert pytest.approx(parameters[1], abs=1e-3) == dummy_atoms[i]["x"] / 10
+        assert pytest.approx(parameters[2], abs=1e-3) == dummy_atoms[i]["y"] / 10
+        assert pytest.approx(parameters[3], abs=1e-3) == dummy_atoms[i]["z"] / 10
+
+    # Test Amber NMR-style restraints
+    atom1, atom2, parameters = DAT_restraint_list[0].getBondParameters(0)
+    assert pytest.approx(parameters[0]) == 2092.0
+    assert pytest.approx(parameters[1]) == 0.6
+
+    atom1, atom2, atom3, parameters = DAT_restraint_list[1].getAngleParameters(0)
+    assert pytest.approx(parameters[0]) == 418.4
+    assert pytest.approx(parameters[1]) == np.pi
+
+    atom1, atom2, atom3, parameters = DAT_restraint_list[2].getAngleParameters(0)
+    assert pytest.approx(parameters[0]) == 418.4
+    assert pytest.approx(parameters[1]) == np.pi
+
+    # Test Amber restraints
+    r_string = amber_restraint_line(guest_restraints[0], window)
+    assert r_string.split()[2].split(",")[0] == "123"
+    assert r_string.split()[2].split(",")[1] == "119"
+    assert float(r_string.split()[4].split(",")[0]) == 0.0
+    assert float(r_string.split()[6].split(",")[0]) == 6.0
+    assert float(r_string.split()[8].split(",")[0]) == 6.0
+    assert float(r_string.split()[10].split(",")[0]) == 999.0
+    assert float(r_string.split()[12].split(",")[0]) == 5.0
+    assert float(r_string.split()[14].split(",")[0]) == 5.0
+
+    theta_string = amber_restraint_line(guest_restraints[1], window)
+    assert theta_string.split()[2].split(",")[0] == "123"
+    assert theta_string.split()[2].split(",")[1] == "119"
+    assert theta_string.split()[2].split(",")[2] == "109"
+    assert float(theta_string.split()[4].split(",")[0]) == 0.0
+    assert float(theta_string.split()[6].split(",")[0]) == 180.0
+    assert float(theta_string.split()[8].split(",")[0]) == 180.0
+    assert float(theta_string.split()[10].split(",")[0]) == 180.0
+    assert float(theta_string.split()[12].split(",")[0]) == 100.0
+    assert float(theta_string.split()[14].split(",")[0]) == 100.0
+
+    # Test Plumed output
+    plumed = Plumed()
+    plumed.path = "tmp"
+    plumed.file_name = "plumed.dat"
+    plumed.window_list = [window]
+    plumed.restraint_list = guest_restraints
+    # plumed.add_dummy_atom_restraints(structure, window)
+    plumed.dump_to_file()
+
+    with open(os.path.join(plumed.path, window, "plumed.dat"), "r") as f:
+        plumed_string = f.readlines()
+
+    for line in plumed_string:
+        if "DISTANCE" in line:
+            restraint_line = line.split()
+            if restraint_line[0] == ":c1":
+                assert restraint_line[2] == "ATOMS=123,119"
+            elif restraint_line[1] == ":c2":
+                assert restraint_line[2] == "ATOMS=123,119,109"
+            elif restraint_line[1] == ":c3":
+                assert restraint_line[2] == "ATOMS=124,123,119"
+
+        if line.startswith("RESTRAINT"):
+            restraint_line = line.split()
+            if "c1" in restraint_line[1]:
+                assert float(restraint_line[2].split("=")[1]) == 6.0
+                assert float(restraint_line[3].split("=")[1]) == 10.0
+            elif "c2" in restraint_line[1]:
+                assert float(restraint_line[2].split("=")[1]) == 3.1416
+                assert float(restraint_line[3].split("=")[1]) == 200.0
+            elif "c3" in restraint_line[1]:
+                assert float(restraint_line[2].split("=")[1]) == 3.1416
+                assert float(restraint_line[3].split("=")[1]) == 200.0
+
+    # Test Colvar output
+    colvar = Colvars()
+    colvar.path = "tmp"
+    colvar.file_name = "colvars.dat"
+    colvar.window_list = [window]
+    colvar.restraint_list = guest_restraints
+    colvar.dump_to_file()
+
+    f = open(os.path.join(colvar.path, window, "colvars.dat"), "r+")
+    for line in f:
+        if "name c1" in line:
+            line = f.readline()
+            line = f.readline()
+            line = f.readline()
+            assert line.strip() == "group1 { atomNumbers 123 }"
+            line = f.readline()
+            assert line.strip() == "group2 { atomNumbers 119 }"
+
+        elif "name c2" in line:
+            line = f.readline()
+            line = f.readline()
+            line = f.readline()
+            assert line.strip() == "group1 { atomNumbers 123 }"
+            line = f.readline()
+            assert line.strip() == "group2 { atomNumbers 119 }"
+            line = f.readline()
+            assert line.strip() == "group3 { atomNumbers 109 }"
+
+        elif "name c3" in line:
+            line = f.readline()
+            line = f.readline()
+            line = f.readline()
+            assert line.strip() == "group1 { atomNumbers 124 }"
+            line = f.readline()
+            assert line.strip() == "group2 { atomNumbers 123 }"
+            line = f.readline()
+            assert line.strip() == "group3 { atomNumbers 119 }"
+
+        elif "colvars c1" in line:
+            line = f.readline()
+            assert line.strip() == "centers 6.0000"
+            line = f.readline()
+            assert line.strip() == "forceConstant 10.0000"
+
+        elif "colvars c2" in line:
+            line = f.readline()
+            assert line.strip() == "centers 180.0000"
+            line = f.readline()
+            assert line.strip() == "forceConstant 0.0609"
+
+        elif "colvars c3" in line:
+            line = f.readline()
+            assert line.strip() == "centers 180.0000"
+            line = f.readline()
+            assert line.strip() == "forceConstant 0.0609"

--- a/paprika/tests/test_tleap.py
+++ b/paprika/tests/test_tleap.py
@@ -8,9 +8,9 @@ import shutil
 import subprocess as sp
 
 import numpy as np
+import openmm.unit as unit
 import parmed as pmd
 import pytest
-import openmm.unit as unit
 from openmm import NonbondedForce
 
 from paprika.build.align import zalign

--- a/paprika/tests/test_tleap.py
+++ b/paprika/tests/test_tleap.py
@@ -10,8 +10,8 @@ import subprocess as sp
 import numpy as np
 import parmed as pmd
 import pytest
-import simtk.unit as unit
-from simtk.openmm import NonbondedForce
+import openmm.unit as unit
+from openmm import NonbondedForce
 
 from paprika.build.align import zalign
 from paprika.build.system import TLeap

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ omit =
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 88
-ignore = E203 ,E266, E501, E741, W503, W605
+ignore = E203 ,E266, E501, E741, W503, W605, F401, F811
 select = B,C,E,F,W,T4,B9
 
 [isort]


### PR DESCRIPTION
This PR updates the import namespace for OpenMM (v7.6.0), the `simtk` namespace will be deprecated in future releases. OpenMM units are now imported as `openmm_unit` and the Pint unit (from `openff.units`) is imported as `pint_unit`. In addition, I added a unit test for the restraint modules.