### PR TITLE
Logger.info output during alignment exception

### DIFF
--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -325,6 +325,7 @@ def get_rotation_matrix(vector, ref_vector):
         x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
     except RuntimeWarning:
         # The structure is already aligned and the denominator is invalid
+        logger.info("The structure is already aligned and the denominator is invalid, skipping")
         pass
 
     theta = np.arccos(

--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -320,16 +320,13 @@ def get_rotation_matrix(vector, ref_vector):
 
     """
     
-    # If the structures are already aligned (cross product is zero), output info
+    # If the structures are already aligned (cross product is zero), return 3x3 identity matrix
     if np.linalg.norm(np.cross(vector, ref_vector)) == 0:
-        logger.info("The structure is already aligned and the denominator is invalid, a harmless exception will occur")
+        logger.info("The structure is already aligned and the denominator is invalid, returning identity matrix.")
+        return np.identity(3)
     
     # Find axis between the mask vector and the axis using cross and dot products.
-    try:
-        x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
-    except RuntimeWarning:
-        # The structure is already aligned and the denominator is invalid
-        pass
+    x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
 
     theta = np.arccos(
         np.dot(vector, ref_vector)

--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -322,15 +322,14 @@ def get_rotation_matrix(vector, ref_vector):
     
     # If the structures are already aligned (cross product is zero), output info
     if np.linalg.norm(np.cross(vector, ref_vector)) == 0:
-        logger.info("The structure is already aligned and the denominator is invalid, skipping")
+        logger.info("The structure is already aligned and the denominator is invalid, a harmless exception will occur")
     
     # Find axis between the mask vector and the axis using cross and dot products.
-    else:
-        try:
-            x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
-        except RuntimeWarning:
-            # The structure is already aligned and the denominator is invalid
-            pass
+    try:
+        x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
+    except RuntimeWarning:
+        # The structure is already aligned and the denominator is invalid
+        pass
 
     theta = np.arccos(
         np.dot(vector, ref_vector)

--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -319,14 +319,18 @@ def get_rotation_matrix(vector, ref_vector):
         A 3x3 rotation matrix.
 
     """
-
-    # Find axis between the mask vector and the axis using cross and dot products.
-    try:
-        x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
-    except RuntimeWarning:
-        # The structure is already aligned and the denominator is invalid
+    
+    # If the structures are already aligned (cross product is zero), output info
+    if np.linalg.norm(np.cross(vector, ref_vector)) == 0:
         logger.info("The structure is already aligned and the denominator is invalid, skipping")
-        pass
+    
+    # Find axis between the mask vector and the axis using cross and dot products.
+    else:
+        try:
+            x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
+        except RuntimeWarning:
+            # The structure is already aligned and the denominator is invalid
+            pass
 
     theta = np.arccos(
         np.dot(vector, ref_vector)


### PR DESCRIPTION
Added a logger.info under get_rotation_matrix for a more informative output than a plain runtime error. The info reads "The structure is already aligned and the denominator is invalid, skipping" when the cross product of the vector and the ref_vector is zero, indicating they are already aligned.