### PR TITLE
Add option to calculate `ref_state_work` for DDM.

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # devtools
   - isort
-  - black
+  - black >=22.1.0
   - flake8
   
   # Documentation

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -32,10 +32,10 @@ class fe_calc(object):
         It would be great to add unit support here from ``pint``.
 
     .. warning ::
-        This class really ought to be split into a few smaller classes that sublcass a ``BaseAnalysis`` class. There
-        could be separate ``MBARAnalysis`` and ``TIAnalysis`` classes, for example. This would make it much more modular
-        and easy to test where TI and MBAR disagree. This could also be used to benchmark autocorrelation-based and
-        blocking-analysis-based methods for evaluating the statistical inefficiency.
+        This class really ought to be split into a few smaller classes that sublcass a ``BaseAnalysis`` class.
+        There could be separate ``MBARAnalysis`` and ``TIAnalysis`` classes, for example. This would make it much
+        more modular and easy to test where TI and MBAR disagree. This could also be used to benchmark
+        autocorrelation-based and blocking-analysis-based methods for evaluating the statistical inefficiency.
 
     """
 
@@ -113,13 +113,14 @@ class fe_calc(object):
     @property
     def orders(self):
         """
-        The sorted order of windows for analysis. In principle, windows could be out-of-order if subsequent additional
-        sampling was requested.
+        The sorted order of windows for analysis. In principle, windows could be out-of-order if subsequent
+        additional sampling was requested.
 
         .. note ::
-            As far as I know, we have not tested analysis on windows out of order. We imagined that one could add additional
-            λ windows through multiple runs by modifying existing restraints (e.g., restraint values of [0, 0.5, 1.0, 0.8])
-            and this module would be able to correctly sort the simulation directories and restraint targets.
+            As far as I know, we have not tested analysis on windows out of order. We imagined that one could add
+            additional λ windows through multiple runs by modifying existing restraints (e.g., restraint values of
+            [0, 0.5, 1.0, 0.8]) and this module would be able to correctly sort the simulation directories and
+            restraint targets.
 
         .. note ::
             This should probably be a private attribute, as this property is determined automatically.
@@ -149,8 +150,8 @@ class fe_calc(object):
     @property
     def methods(self):
         """
-        list: List of analysis methods to be performed. This is a combination of free energy method (e.g., MBAR, TI, ...)
-        and de-correlation method (blocking, autocorrelation, ...).
+        list: List of analysis methods to be performed. This is a combination of free energy method (e.g., MBAR, TI,
+        ...) and de-correlation method (blocking, autocorrelation, ...).
 
         Implemented methods are:
 
@@ -159,8 +160,8 @@ class fe_calc(object):
             - ``ti-block``
 
         .. note ::
-            This is really fragile. We should definitely use something like an ``ENUM`` here to check for the few combinations
-            that we support.
+            This is really fragile. We should definitely use something like an ``ENUM`` here to check for the few
+            combinations that we support.
 
         .. todo ::
             - Add ``ti-autoc``.
@@ -229,15 +230,15 @@ class fe_calc(object):
     @property
     def ti_matrix(self):
         """
-        str: If ``full``, the TI mean and SEM free energy is computed between all windows (i.e., the energy differences between
-        all windows and all other windows). If ``diagonal``, the mean and SEM of the free energy is computed between the
-        first window and all other windows, as well as between all neighboring windows. If ``endpoints``, the mean and
-        SEM free energy is computed between only the first and the last window.
+        str: If ``full``, the TI mean and SEM free energy is computed between all windows (i.e., the energy differences
+        between all windows and all other windows). If ``diagonal``, the mean and SEM of the free energy is computed
+        between the first window and all other windows, as well as between all neighboring windows. If ``endpoints``,
+        the mean and SEM free energy is computed between only the first and the last window.
 
         For most cases, ``diagonal`` should be sufficient and ``full`` is overkill.
 
         .. note ::
-            This is fragile and we should be checking for the valid strings supported.
+            This is fragile, and we should be checking for the valid strings supported.
 
         """
         return self._ti_matrix
@@ -254,8 +255,8 @@ class fe_calc(object):
     def exact_sem_each_ti_fraction(self):
         """
         bool: Whether the SEM is computed once for the full data set and then the SEM for each fraction is estimated
-        based on the total SEM and the fractional number of uncorrelated data points. If ``True``, the SEM will be recomputed
-        each fraction using just that fraction of the raw data.
+        based on the total SEM and the fractional number of uncorrelated data points. If ``True``, the SEM will be
+        recomputed each fraction using just that fraction of the raw data.
         """
         return self._exact_sem_each_ti_fraction
 
@@ -284,15 +285,15 @@ class fe_calc(object):
     @property
     def results(self):
         """
-        dict: A dictionary containing the results. The results dictionary is indexed first by phase, and then by
+        dict: A dictionary containing the results. The ``results`` dictionary is indexed first by phase, and then by
         method. That is, ``results["attach"]["mbar-block"]`` will contain the results from analyzing the attach
         phase with the MBAR free energy estimator and blocking analysis used to estimate the SEM.
 
         The final free energy and uncertainty estimate is specified in the ``fe`` and ``sem`` keys.
 
         If multiple fractions of the data are specified, the free energy and SEM from each fraction are stored in
-        a nested dictionary under the keys ``fraction_fe`` and ``fractrion_sem``. The number of frames analyzed for
-        each fraciton is stored under ``fraction_n_frames``.
+        a nested dictionary under the keys ``fraction_fe`` and ``fraction_sem``. The number of frames analyzed for
+        each fraction is stored under ``fraction_n_frames``.
 
         The full free energy matrix (window-to-window free energy differences) is stored in the ``fe_matrix`` entry.
         Likewise, the full SEM matrix (window-to-window free energy SEMs) is stored in the ``sem_matrix`` entry.
@@ -528,7 +529,7 @@ class fe_calc(object):
         return orders
 
     def read_trajectories(self, single_topology=False):
-        """For each each phase and window, and for each non-static restraint, parse the trajectories to
+        """For each phase and window, and for each non-static restraint, parse the trajectories to
         get the restraint values.
 
         Parameters
@@ -667,7 +668,8 @@ class fe_calc(object):
 
     def run_mbar(self, phase, prepared_data, method, verbose=False):
         """
-        Compute the free energy matrix for a series of windows. We'll follow the pymbar nomenclature for data structures.
+        Compute the free energy matrix for a series of windows. We'll follow the pymbar nomenclature
+        for data structures.
 
         Parameters
         ----------
@@ -1248,9 +1250,9 @@ class fe_calc(object):
         ----------
         restraints : list or dict
             A list or dict of :class:`paprika.restraints.DAT_restraint` objects. If a list is specified, the restraints
-            must be in order of the six translational and orientational Boresch-restraints. The six restraints are:
-            [r, theta, phi, alpha, beta, gamma] and they should be passed to this function in that order. If any of
-            these coordinates is not being restrained, use a `None` in place of a
+            must be in order of the six translational and orientational restraints (Boresch-style). The six restraints
+            are: [r, theta, phi, alpha, beta, gamma] and they should be passed to this function in that order. If any
+            of these coordinates is not being restrained, use a `None` in place of a
             :class:`paprika.restraints.DAT_restraint` object. For a dictionary, the restraints should have `r`, `theta`,
             `phi`, `alpha`, `beta`, `gamma`, as the dictionary keys.
 

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -290,9 +290,9 @@ class fe_calc(object):
 
         The final free energy and uncertainty estimate is specified in the ``fe`` and ``sem`` keys.
 
-        If multiple fractions of the data are specified, the free energy and SEM from each fraction are stored in a nested
-        dictionary under the keys ``fraction_fe`` and ``fractrion_sem``. The number of frames analyzed for each fraciton
-        is stored under ``fraction_n_frames``.
+        If multiple fractions of the data are specified, the free energy and SEM from each fraction are stored in
+        a nested dictionary under the keys ``fraction_fe`` and ``fractrion_sem``. The number of frames analyzed for
+        each fraciton is stored under ``fraction_n_frames``.
 
         The full free energy matrix (window-to-window free energy differences) is stored in the ``fe_matrix`` entry.
         Likewise, the full SEM matrix (window-to-window free energy SEMs) is stored in the ``sem_matrix`` entry.
@@ -300,8 +300,8 @@ class fe_calc(object):
         The work to release the guest to standard concentration is stored under ``ref_state_work``, and is
         negative by convention.
 
-        The format of a typical dictionary will resemble this (where I have a omitted the values in the matrices for
-        clarity):
+        The format of a typical dictionary will resemble this (where I have a omitted the values in the matrices
+        for clarity):
 
         ::
 
@@ -1275,7 +1275,7 @@ class fe_calc(object):
                 "gamma": restraints[5],
             }
 
-        # Raise error is no distance restraint is not included
+        # Raise error if no distance restraint exist
         if not restraints or restraints["r"] is None:
             raise ValueError(
                 "At minimum, a single distance restraint is necessary to compute the work of releasing "
@@ -1299,25 +1299,34 @@ class fe_calc(object):
 
             else:
                 target_and_force_exist = False
-                for phase in ["attach", "pull", "release"]:
+
+                phases = ["release", "pull"]
+                if state == "initial":
+                    phases = ["attach", "release"]
+
+                for phase in phases:
                     if restraint.phase[phase] is not None:
+                        force_index = -1
+                        if phase == "release":
+                            force_index = 0
+
                         fcs.append(
-                            np.sort(restraints["r"].phase["attach"]["force_constants"])[
-                                -1
+                            np.sort(restraint.phase[phase]["force_constants"])[
+                                force_index
                             ]
                         )
                         targs.append(
-                            np.sort(restraints["r"].phase["attach"]["targets"])[
-                                target_index
-                            ]
+                            np.sort(restraint.phase[phase]["targets"])[target_index]
                         )
+
                         target_and_force_exist = True
+
                         break
 
                 if not target_and_force_exist:
                     raise ValueError(
-                        f"The `{colvar}` restraints should have attach/release values (for DDM) or pull/release "
-                        f"values (for APR) initialized in order to `compute_ref_state_work`."
+                        f"The `{colvar}` restraints should have at least attach/release values (for DDM) or "
+                        "pull/release values (for APR) initialized in order to `compute_ref_state_work`."
                     )
 
         # Store reference work of release guest restraints

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -1257,8 +1257,15 @@ class fe_calc(object):
             See :meth:`paprika.analysis.ref_state_work` for details on the calculation.
         state : str, optional, default="final"
             Option to estimate the reference work using the `initial` state (DDM) or `final` pulling state (APR) for
-            `r0` when calculating the reference work of releasing guest restraints in bulk water.
+            `r0` when calculating the reference work of releasing guest restraints in bulk water. See Equation 9 in ref
+            Henriksen et al. (2015).
         """
+        # Check input argument
+        state = state.lower()
+        if state not in ["initial", "final"]:
+            raise ValueError(
+                'Function argument `state` can only take values "initial" or "final" as input.'
+            )
 
         # Convert list to dictionary
         if isinstance(restraints, list):

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -1302,10 +1302,14 @@ class fe_calc(object):
                 for phase in ["attach", "pull", "release"]:
                     if restraint.phase[phase] is not None:
                         fcs.append(
-                            np.sort(restraints["r"].phase["attach"]["force_constants"])[-1]
+                            np.sort(restraints["r"].phase["attach"]["force_constants"])[
+                                -1
+                            ]
                         )
                         targs.append(
-                            np.sort(restraints["r"].phase["attach"]["targets"])[target_index]
+                            np.sort(restraints["r"].phase["attach"]["targets"])[
+                                target_index
+                            ]
                         )
                         target_and_force_exist = True
                         break

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -759,7 +759,7 @@ class fe_calc(object):
                 nearest_max = get_nearest_max(N_k[k])
                 sem = get_block_sem(u_kln[k, l, 0:nearest_max])
                 variance = np.var(u_kln[k, l, 0 : N_k[k]])
-                g_k[k] = N_k[k] * (sem ** 2) / variance
+                g_k[k] = N_k[k] * (sem**2) / variance
 
         if method == "mbar-autoc":
             for k in range(num_win):
@@ -1760,7 +1760,7 @@ def ref_state_work(
     # Distance Integration Function
     def dist_int(RT, fc, targ):
         def potential(arange, RT, fc, targ):
-            return (arange ** 2) * np.exp((-1.0 / RT) * fc * (arange - targ) ** 2)
+            return (arange**2) * np.exp((-1.0 / RT) * fc * (arange - targ) ** 2)
 
         arange = np.arange(0.0, 100.0, 0.0001) * unit.angstrom
         return np.trapz(potential(arange, RT, fc, targ), arange)
@@ -1819,11 +1819,11 @@ def ref_state_work(
         g_int = tors_int(RT, g_fc, g_tg)
 
     # Concentration term
-    V0 = 1660.5392 * unit.angstrom ** 3
+    V0 = 1660.5392 * unit.angstrom**3
     translational = r_int * th_int * ph_int * (1.0 / V0)  # C^o = 1/V^o
 
     # Orientational term
-    rotational_volume = 8.0 * np.pi ** 2
+    rotational_volume = 8.0 * np.pi**2
     orientational = a_int * b_int * g_int / rotational_volume
 
     # Return the free energy

--- a/paprika/analysis.py
+++ b/paprika/analysis.py
@@ -1312,7 +1312,7 @@ class fe_calc(object):
                     phases = ["attach", "release"]
 
                 for phase in phases:
-                    if restraint.phase[phase] is not None:
+                    if restraint.phase[phase]["force_constants"] is not None:
                         force_index = -1
                         if phase == "release":
                             force_index = 0
@@ -1779,6 +1779,7 @@ def ref_state_work(
             return np.exp((-1.0 / RT) * fc * (arange - targ) ** 2)
 
         # Note, because of periodicity, I'm gonna wrap +/- pi around target for integration.
+        targ = targ.to(unit.radians).magnitude
         arange = np.arange(targ - np.pi, targ + np.pi, 0.00005) * unit.radians
         return np.trapz(potential(arange, RT, fc, targ), arange)
 

--- a/paprika/build/align.py
+++ b/paprika/build/align.py
@@ -319,12 +319,12 @@ def get_rotation_matrix(vector, ref_vector):
         A 3x3 rotation matrix.
 
     """
-    
+
     # If the structures are already aligned (cross product is zero), return 3x3 identity matrix
     if np.linalg.norm(np.cross(vector, ref_vector)) == 0:
         logger.info("The structure is already aligned and the denominator is invalid, returning identity matrix.")
         return np.identity(3)
-    
+
     # Find axis between the mask vector and the axis using cross and dot products.
     x = np.cross(vector, ref_vector) / np.linalg.norm(np.cross(vector, ref_vector))
 

--- a/paprika/restraints/amber.py
+++ b/paprika/restraints/amber.py
@@ -89,9 +89,9 @@ def amber_restraint_line(restraint, window):
         if restraint.restraint_type == "distance"
         else pint_unit.degrees
     )
-    force_constant_unit = energy_unit / target_unit ** 2
+    force_constant_unit = energy_unit / target_unit**2
     if not restraint.restraint_type == "distance":
-        force_constant_unit = energy_unit / pint_unit.radians ** 2
+        force_constant_unit = energy_unit / pint_unit.radians**2
 
     # Prepare AMBER NMR-style restraint
     atoms = "".join([iat1, iat2, iat3, iat4])

--- a/paprika/restraints/colvars.py
+++ b/paprika/restraints/colvars.py
@@ -153,7 +153,7 @@ class Colvars(Plumed):
                 if restraint.restraint_type == "distance":
                     target = target.to(pint_unit.angstrom)
                     force_constant = force_constant.to(
-                        energy_units / pint_unit.angstrom ** 2
+                        energy_units / pint_unit.angstrom**2
                     )
                 elif (
                     restraint.restraint_type == "angle"
@@ -161,7 +161,7 @@ class Colvars(Plumed):
                 ):
                     target = target.to(pint_unit.degrees)
                     force_constant = force_constant.to(
-                        energy_units / pint_unit.degrees ** 2
+                        energy_units / pint_unit.degrees**2
                     )
 
                 # Determine bias type for this restraint
@@ -339,7 +339,7 @@ class Colvars(Plumed):
         """
         # Check k units
         kpos = check_unit(
-            kpos, base_unit=pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+            kpos, base_unit=pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
         )
 
         # Get dummy atom indices

--- a/paprika/restraints/openmm.py
+++ b/paprika/restraints/openmm.py
@@ -63,7 +63,7 @@ def apply_positional_restraints(
                 k = (
                     kpos
                     * openmm_unit.kilocalories_per_mole
-                    / openmm_unit.angstroms ** 2
+                    / openmm_unit.angstroms**2
                 )
             elif isinstance(kpos, openmm_unit.Quantity):
                 k = kpos

--- a/paprika/restraints/openmm.py
+++ b/paprika/restraints/openmm.py
@@ -2,8 +2,14 @@
 import logging
 
 import numpy as np
-import openmm as openmm
-import openmm.unit as openmm_unit
+
+try:
+    import simtk.openmm as openmm
+    import simtk.unit as openmm_unit
+except ImportError:
+    import openmm
+    import openmm.unit as openmm_unit
+
 import parmed as pmd
 from openff.units import unit as pint_unit
 from openff.units.simtk import to_simtk

--- a/paprika/restraints/plumed.py
+++ b/paprika/restraints/plumed.py
@@ -274,7 +274,7 @@ class Plumed:
                 ):
                     target = target.to(pint_unit.radians)
                     force_constant = force_constant.to(
-                        self.output_units["energy"] / pint_unit.radians ** 2
+                        self.output_units["energy"] / pint_unit.radians**2
                     )
 
                 # Determine bias type for this restraint

--- a/paprika/restraints/restraints.py
+++ b/paprika/restraints/restraints.py
@@ -579,10 +579,10 @@ class DAT_restraint(object):
         # Set default units (Based on Amber)
         energy_unit = pint_unit.kcal / pint_unit.mole
         target_unit = pint_unit.angstrom
-        force_constant_unit = energy_unit / pint_unit.angstrom ** 2
+        force_constant_unit = energy_unit / pint_unit.angstrom**2
         if self.mask3 or self.mask4:
             target_unit = pint_unit.degrees
-            force_constant_unit = energy_unit / pint_unit.radians ** 2
+            force_constant_unit = energy_unit / pint_unit.radians**2
 
         # Check attach/release units
         for phase in [self._attach, self._release]:
@@ -947,9 +947,9 @@ def static_DAT_restraint(
     force_constant = check_unit(
         force_constant,
         base_unit=(
-            pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+            pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
             if len(restraint_mask_list) == 2
-            else pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
+            else pint_unit.kcal / pint_unit.mole / pint_unit.radians**2
         ),
     )
 

--- a/paprika/restraints/utils.py
+++ b/paprika/restraints/utils.py
@@ -171,7 +171,9 @@ def get_bias_potential_type(restraint, phase, window_number):
     return bias_type
 
 
-def extract_guest_restraints(structure, restraints, guest_resname, dummy_prefix="DM"):
+def extract_guest_restraints(
+    structure, restraints, guest_resname, dummy_prefix="DM", return_type="dict"
+):
     """
     Utility function to extract the guest restraints from a list of restraints
     and return individual restraints in the form ``[r, theta, phi, alpha, beta, gamma]``.
@@ -192,10 +194,12 @@ def extract_guest_restraints(structure, restraints, guest_resname, dummy_prefix=
         Residue name of the guest molecule.
     dummy_prefix : str, optional, default="DM"
         The prefix for the dummy atoms residue name.
+    return_type : str, optional, default="dict"
+        Option to return guest restraints as a list or a dict
 
     Returns
     -------
-    guest_restraints : list
+    guest_restraints : list or dict
         list of guest-specific :class:`paprika.restraints.DAT_restraint` restraints.
 
     Examples
@@ -282,7 +286,21 @@ def extract_guest_restraints(structure, restraints, guest_resname, dummy_prefix=
             ):
                 gamma = restraint
 
-    guest_restraints = [r, theta, phi, alpha, beta, gamma]
+    if return_type == "list":
+        guest_restraints = [r, theta, phi, alpha, beta, gamma]
+    elif return_type == "dict":
+        guest_restraints = {
+            "r": r,
+            "theta": theta,
+            "phi": phi,
+            "alpha": alpha,
+            "beta": beta,
+            "gamma": gamma,
+        }
+    else:
+        raise KeyError(
+            "`return_type` argument not valid. Only `list` or `dict` are accepted."
+        )
 
     return guest_restraints
 

--- a/paprika/restraints/utils.py
+++ b/paprika/restraints/utils.py
@@ -213,6 +213,13 @@ def extract_guest_restraints(
         >>> print(free_energy["ref_state_work"])
 
     """
+    # Check input argument
+    return_type = return_type.lower()
+    if return_type not in ["list", "dict"]:
+        raise ValueError(
+            'Function argument `return_type` can only take values "list" or "dict" as input.'
+        )
+
     guest_resname = guest_resname.upper()
 
     DM1 = f"{dummy_prefix}1"
@@ -288,6 +295,7 @@ def extract_guest_restraints(
 
     if return_type == "list":
         guest_restraints = [r, theta, phi, alpha, beta, gamma]
+
     elif return_type == "dict":
         guest_restraints = {
             "r": r,
@@ -297,6 +305,7 @@ def extract_guest_restraints(
             "beta": beta,
             "gamma": gamma,
         }
+
     else:
         raise KeyError(
             "`return_type` argument not valid. Only `list` or `dict` are accepted."

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -58,7 +58,7 @@ def test_DAT_restraint():
     rest1.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / target_units ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / target_units**2
     assert rest1.index1 == [13, 31, 49, 67, 85, 103]
     assert rest1.index2 == [119]
     assert rest1.index3 is None
@@ -127,7 +127,7 @@ def test_DAT_restraint():
     rest2.initialize()
 
     target_units = pint_unit.degrees
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians**2
     assert rest2.index1 == [13, 31, 49, 67, 85, 103]
     assert rest2.index2 == [119]
     assert rest2.index3 == [109]
@@ -195,7 +195,7 @@ def test_DAT_restraint():
     rest3.initialize()
 
     target_units = pint_unit.degrees
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians**2
     assert rest3.index1 == [31]
     assert rest3.index2 == [13]
     assert rest3.index3 == [119]
@@ -265,7 +265,7 @@ def test_DAT_restraint():
     rest4.initialize()
 
     target_units = pint_unit.degrees
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.radians**2
     assert rest4.index1 == [31]
     assert rest4.index2 == [13]
     assert rest4.index3 == [119]
@@ -333,7 +333,7 @@ def test_DAT_restraint():
     rest5.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
     assert rest5.index1 == [13, 31, 49, 67, 85, 103]
     assert rest5.index2 == [109, 113, 115, 119]
     assert rest5.index3 is None
@@ -400,7 +400,7 @@ def test_DAT_restraint():
     rest6.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
     assert rest6.index1 == [13, 31, 49, 67, 85, 103]
     assert rest6.index2 == [109, 113, 115, 119]
     assert rest6.index3 is None
@@ -467,7 +467,7 @@ def test_DAT_restraint():
     rest7.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
     assert rest7.index1 == [13, 14, 111]
     assert rest7.index2 == [3]
     assert rest7.index3 is None
@@ -528,7 +528,7 @@ def test_DAT_restraint():
     rest8.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
     assert rest8.index1 == [13]
     assert rest8.index2 == [119]
     assert rest8.index3 is None
@@ -566,7 +566,7 @@ def test_DAT_restraint():
     rest9.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
     assert rest9.index1 == [13]
     assert rest9.index2 == [119]
     assert rest9.index3 is None
@@ -604,7 +604,7 @@ def test_DAT_restraint():
     rest10.initialize()
 
     target_units = pint_unit.angstrom
-    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom ** 2
+    force_constant_units = pint_unit.kcal / pint_unit.mole / pint_unit.angstrom**2
     assert rest10.index1 == [13]
     assert rest10.index2 == [119]
     assert rest10.index3 is None
@@ -1238,7 +1238,7 @@ def test_restraints_output_modules(clean_files):
     )
 
     # Create restraints for OpenMM system
-    kpos = 50.0 * openmm_unit.kilocalories_per_mole / openmm_unit.angstrom ** 2
+    kpos = 50.0 * openmm_unit.kilocalories_per_mole / openmm_unit.angstrom**2
     apply_positional_restraints(
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"),
         system,
@@ -1264,7 +1264,7 @@ def test_restraints_output_modules(clean_files):
     for i, force in enumerate(positional_restraints):
         particle, parameters = force.getParticleParameters(0)
         assert pytest.approx(parameters[0], abs=1e-3) == kpos.value_in_unit(
-            openmm_unit.kilojoule_per_mole / openmm_unit.nanometer ** 2
+            openmm_unit.kilojoule_per_mole / openmm_unit.nanometer**2
         )
         assert pytest.approx(parameters[1], abs=1e-3) == dummy_atoms[i]["x"] / 10
         assert pytest.approx(parameters[2], abs=1e-3) == dummy_atoms[i]["y"] / 10

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -5,9 +5,16 @@ import logging
 import os
 
 import numpy as np
-import openmm
-import openmm.app as app
-import openmm.unit as openmm_unit
+
+try:
+    import simtk.openmm as openmm
+    import simtk.openmm.app as app
+    import simtk.unit as openmm_unit
+except ImportError:
+    import openmm
+    import openmm.app as app
+    import openmm.unit as openmm_unit
+
 import parmed as pmd
 import pytest
 from openff.units import unit as pint_unit
@@ -981,7 +988,9 @@ def test_extract_guest_restraints():
         os.path.join(os.path.dirname(__file__), "../data/cb6-but/cb6-but-dum.pdb"),
         structure=True,
     )
-    guest_restraints = extract_guest_restraints(structure, restraints, "BUT")
+    guest_restraints = extract_guest_restraints(
+        structure, restraints, "BUT", return_type="list"
+    )
 
     assert guest_restraints[0] is not None
     assert guest_restraints[1] is not None
@@ -1017,7 +1026,9 @@ def test_extract_guest_restraints():
     r.initialize()
     restraints.append(r)
 
-    guest_restraints = extract_guest_restraints(structure, restraints, "BUT")
+    guest_restraints = extract_guest_restraints(
+        structure, restraints, "BUT", return_type="list"
+    )
 
     assert guest_restraints[0] is not None
     assert guest_restraints[1] is not None
@@ -1053,7 +1064,9 @@ def test_extract_guest_restraints():
     r.initialize()
     restraints.append(r)
 
-    guest_restraints = extract_guest_restraints(structure, restraints, "BUT")
+    guest_restraints = extract_guest_restraints(
+        structure, restraints, "BUT", return_type="list"
+    )
 
     assert guest_restraints[0] is not None
     assert guest_restraints[1] is not None
@@ -1089,7 +1102,9 @@ def test_extract_guest_restraints():
     r.initialize()
     restraints.append(r)
 
-    guest_restraints = extract_guest_restraints(structure, restraints, "BUT")
+    guest_restraints = extract_guest_restraints(
+        structure, restraints, "BUT", return_type="list"
+    )
 
     assert guest_restraints[0] is not None
     assert guest_restraints[1] is not None

--- a/paprika/tests/test_restraints.py
+++ b/paprika/tests/test_restraints.py
@@ -1102,9 +1102,11 @@ def test_extract_guest_restraints():
     r.initialize()
     restraints.append(r)
 
+    # Test list
     guest_restraints = extract_guest_restraints(
         structure, restraints, "BUT", return_type="list"
     )
+    assert isinstance(guest_restraints, list)
 
     assert guest_restraints[0] is not None
     assert guest_restraints[1] is not None
@@ -1112,6 +1114,19 @@ def test_extract_guest_restraints():
     assert guest_restraints[3] is not None
     assert guest_restraints[4] is not None
     assert guest_restraints[5] is not None
+
+    # Test dict
+    guest_restraints = extract_guest_restraints(
+        structure, restraints, "BUT", return_type="dict"
+    )
+    assert isinstance(guest_restraints, dict)
+
+    assert guest_restraints["r"] is not None
+    assert guest_restraints["theta"] is not None
+    assert guest_restraints["phi"] is not None
+    assert guest_restraints["alpha"] is not None
+    assert guest_restraints["beta"] is not None
+    assert guest_restraints["gamma"] is not None
 
 
 def test_restraints_output_modules(clean_files):

--- a/paprika/tests/test_tleap.py
+++ b/paprika/tests/test_tleap.py
@@ -282,8 +282,8 @@ def test_solvation_by_M_and_m(clean_files):
 
     volume = sys.get_volume()
     volume_in_liters = volume * ANGSTROM_CUBED_TO_LITERS
-    calc_num_na = np.ceil((6.022 * 10 ** 23) * 0.150 * volume_in_liters)
-    calc_num_cl = np.ceil((6.022 * 10 ** 23) * 0.150 * volume_in_liters)
+    calc_num_na = np.ceil((6.022 * 10**23) * 0.150 * volume_in_liters)
+    calc_num_cl = np.ceil((6.022 * 10**23) * 0.150 * volume_in_liters)
     assert int(obs_num_na) == int(calc_num_na)
     assert int(obs_num_cl) == int(calc_num_cl)
 

--- a/paprika/tests/test_tleap.py
+++ b/paprika/tests/test_tleap.py
@@ -8,10 +8,16 @@ import shutil
 import subprocess as sp
 
 import numpy as np
-import openmm.unit as unit
+
+try:
+    import simtk.openmm as openmm
+    import simtk.unit as unit
+except ImportError:
+    import openmm
+    import openmm.unit as unit
+
 import parmed as pmd
 import pytest
-from openmm import NonbondedForce
 
 from paprika.build.align import zalign
 from paprika.build.system import TLeap
@@ -134,7 +140,9 @@ def test_solvation_bind3p(clean_files):
     ]
     system = structure.createSystem()
     nonbonded = [
-        force for force in system.getForces() if isinstance(force, NonbondedForce)
+        force
+        for force in system.getForces()
+        if isinstance(force, openmm.NonbondedForce)
     ][0]
     oxygen = nonbonded.getParticleParameters(water_index[0])
     assert (


### PR DESCRIPTION
This PR adds the option to use the initial pulling state for `r0` when calculating the reference work in `compute_ref_state_work`. This is useful for estimating the reference work for DDM calculations where we release the restraints on the guest molecule at the binding site. I will add a feature for system building, configuring restraints, and FE analysis for DDM calculations in a future PR.