### PR TITLE
Added prmtop to openmm tutorial

### DIFF
--- a/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
+++ b/docs/tutorials/04-tutorial-cb6-but-openmm.ipynb
@@ -921,6 +921,7 @@
    "outputs": [],
    "source": [
     "free_energy = analysis.fe_calc()\n",
+    "free_energy.prmtop = \"cb6-but-dum.prmtop\"\n",
     "free_energy.topology = \"system.pdb\"\n",
     "free_energy.trajectory = \"production.dcd\"\n",
     "free_energy.path = work_dir\n",


### PR DESCRIPTION
Running the openmm tutorial currently creates errors during the analysis phase due to the absence of a `prmtop` file attribute of the `analysis.fe_calc()` object `free_energy`. Since `cb6-but-dum.prmtop` is already easily accessible in each window, this PR serves as a quick fix to avoid errors along the lines of `could not initialize prmtop topology directly` and/or `0-atom structure`.

I haven't gotten the chance to try running the gromacs or namd tutorials, but if a similar issue is found in those notebooks defining the `prmtop` attribute might also be a fix for them.

Questions:
- Is a prmtop file really necessary here? Is it required because some part of the analysis pipeline assumes that the simulation was run with AMBER? If that's the case, this won't fix the underlying issue, just add a bandage
- Is this error also created when running the tutorials for gromacs and namd? I haven't checked yet but I hypothesize the error will occur in all non-AMBER tutorials